### PR TITLE
Typed tables

### DIFF
--- a/src/strategies/property.sml
+++ b/src/strategies/property.sml
@@ -55,7 +55,8 @@ fun compare (Simple s, Simple s') = String.compare (s, s')
                      end  ;
 
 (*propertyMatch is meant to be used for finding whether a correspondence holds
-  without the need to have type or attribute information *)
+  without the need to have type or attribute information, and type-matching when
+  there is type information *)
 fun propertyMatch (Simple s, p) = (s = nameOf p)
   | propertyMatch (p, Simple s) = (s = nameOf p)
   | propertyMatch (Typed (s,t), Typed (s',t')) = (s = s' andalso Type.unify t t')

--- a/src/strategies/property_correspondence.sml
+++ b/src/strategies/property_correspondence.sml
@@ -36,11 +36,25 @@ fun emptyIntn a b = S.isEmpty (S.intersection a b);
 
 fun strength (_, _, s) = s;
 
+fun propertyMatches p ps =
+  let 
+      val ms = S.filter (fn v => Property.propertyMatch (p,v)) ps
+  in not (S.isEmpty ms)
+  end
+
+fun allPropertiesMatch ps ps' =
+   let val contained = S.map (fn p => propertyMatches p ps') ps;
+   in all contained end;
+
+ fun somePropertiesMatch ps ps' =
+    let val contained = S.map (fn p => propertyMatches p ps') ps;
+    in any contained end;
+
 fun match qs rs ((qp, qn), (rp, rn), _) =
-    (S.subset qp qs) andalso
-    (S.subset rp rs) andalso
-    (emptyIntn qn qs) andalso
-    (emptyIntn rn rs);
+    (allPropertiesMatch qp qs) andalso
+    (allPropertiesMatch rp rs) andalso
+    (not (somePropertiesMatch qn qs)) andalso
+    (not (somePropertiesMatch rn rs));
 
 fun sameProperties ((qp, qn), (rp, rn), _) ((qp', qn'), (rp', rn'), _) =
     S.equal (qp, qp') andalso

--- a/src/strategies/property_correspondence.sml
+++ b/src/strategies/property_correspondence.sml
@@ -15,7 +15,9 @@ sig
 
     val equal : correspondence -> correspondence -> bool;
     val match : S.t S.set -> S.t S.set -> correspondence -> bool;
+    val matchingIntersectionLeft : S.t S.set -> S.t S.set -> S.t S.set;
     val sameProperties : correspondence -> correspondence -> bool;
+    val matchingProperties : correspondence -> correspondence -> bool;
     val strength : correspondence -> real;
 
     val toString : correspondence -> string;
@@ -36,25 +38,42 @@ fun emptyIntn a b = S.isEmpty (S.intersection a b);
 
 fun strength (_, _, s) = s;
 
-fun propertyMatches p ps =
-  let 
-      val ms = S.filter (fn v => Property.propertyMatch (p,v)) ps
-  in not (S.isEmpty ms)
-  end
+fun filterMatches p ps = S.filter (fn v => Property.propertyMatch (p,v)) ps;
+
+fun propertyMatches p ps = not (S.isEmpty (filterMatches p ps));
 
 fun allPropertiesMatch ps ps' =
-   let val contained = S.map (fn p => propertyMatches p ps') ps;
-   in all contained end;
+    let val contained = S.map (fn p => propertyMatches p ps') ps;
+    in all contained end;
 
- fun somePropertiesMatch ps ps' =
+fun somePropertiesMatch ps ps' =
     let val contained = S.map (fn p => propertyMatches p ps') ps;
     in any contained end;
+
+fun joinSets [] = S.empty ()
+  | joinSets (h::t) = S.union h (joinSets t)
+
+(* finds matches between two property sets,
+but only returns the matches of the left (ps) *)
+fun matchingIntersectionLeft ps ps' =
+    let val x = S.map (fn p => filterMatches p ps) ps'
+    in foldr (fn (a,b) => S.union a b) (S.empty ()) x
+    end;
+
 
 fun match qs rs ((qp, qn), (rp, rn), _) =
     (allPropertiesMatch qp qs) andalso
     (allPropertiesMatch rp rs) andalso
     (not (somePropertiesMatch qn qs)) andalso
     (not (somePropertiesMatch rn rs));
+
+fun biMatch (ps,ps') = allPropertiesMatch ps ps' andalso allPropertiesMatch ps' ps
+
+fun matchingProperties ((qp, qn), (rp, rn), _) ((qp', qn'), (rp', rn'), _) =
+    biMatch (qp, qp') andalso
+    biMatch (qn, qn') andalso
+    biMatch (rp, rp') andalso
+    biMatch (rn, rn');
 
 fun sameProperties ((qp, qn), (rp, rn), _) ((qp', qn'), (rp', rn'), _) =
     S.equal (qp, qp') andalso

--- a/src/strategies/representation_selection.sml
+++ b/src/strategies/representation_selection.sml
@@ -44,7 +44,7 @@ fun init (repTables, corrTables, qTables) = let
       | dedupCorrespondences (x::xs) = let
           fun removeCorr y [] = []
             | removeCorr y (z::zs) =
-              if Correspondence.sameProperties y z
+              if Correspondence.matchingProperties y z
               then (
                   if Correspondence.equal y z then
                       zs
@@ -126,10 +126,12 @@ fun propInfluence (q, r, s) =
                                 (fn p => ((PropertySet.fromList [p], PropertySet.empty ()),
                                           (PropertySet.fromList [p], PropertySet.empty ()),
                                           1.0))
-                                (PropertySet.intersection qProps rProps);
+                              (*)  (PropertySet.intersection qProps rProps);*)
+                                (Correspondence.matchingIntersectionLeft qProps rProps);
         val identityPairs' = List.filter (fn corr =>
                                              not(List.exists
-                                                     (Correspondence.sameProperties corr)
+                                                     (*(Correspondence.sameProperties corr)*)
+                                                     (Correspondence.matchingProperties corr)
                                                             propertyPairs'))
                                                 identityPairs;
         val propertyPairs = map liftImportance (identityPairs' @ propertyPairs');

--- a/src/strategies/tables/Q_table_birds_bayes.csv
+++ b/src/strategies/tables/Q_table_birds_bayes.csv
@@ -1,0 +1,15 @@
+birds,
+error-allowed,0
+answer-type,real
+instrumental-tokens,"\Pr,\cap,\bar,="
+instrumental-types,"real,event"
+instrumental-patterns,"\Pr(_:event|_:event) = _:real, \Pr(_:event \cap _:event) = _:real"
+instrumental-facts,"$Bayes'_theorem, $law_of_total_probability, $non_negative_probability, $unit_measure, $sigma_additivity"
+instrumental-tactics,"rewrite,calc"
+relevant-tokens,"1, \div, 4, b, f, \Omega, 2, 3, |"
+relevant-related-tokens,"*, +, -, \cup, 0, assume, calculate"
+num-tokens,30
+num-distinct-tokens,12
+num-statements,4
+noise-tokens,""
+noise-related-tokens,""

--- a/src/strategies/tables/Q_table_birds_natlang.csv
+++ b/src/strategies/tables/Q_table_birds_natlang.csv
@@ -5,7 +5,7 @@ instrumental-tokens,"probability,and,not"
 instrumental-types,"ratio,class"
 instrumental-patterns,"_:ratio of _:class are _:class,probability of _:class and _:class"
 instrumental-facts,"$Bayes'_theorem, $law_of_total_probability, $non_negative_probability, $unit_measure, $sigma_additivity"
-instrumental-tactics,"deduce,calculate"
+instrumental-tactics,"deduction, arithmetic_calculation"
 relevant-tokens,"one, quarter, all, animals, birds, two, thirds, can, fly, half, flying, X, animal, probability, cannot"
 relevant-related-tokens,"times, divided_by, plus, minus, equals, union, intersection, probability, zero"
 num-tokens,67

--- a/src/strategies/tables/RS_table_bayes.csv
+++ b/src/strategies/tables/RS_table_bayes.csv
@@ -1,14 +1,14 @@
 bayes,
 mode,"sentential"
 types,"real,event,formula,proof"
-tokens,"\forall,\Omega,\emptyset, 0,1,2,3,4,5,6,7,8,9,+,-,*,\div,\cup,\cap,\setminus,=,\Pr, |,="
+tokens,"\forall,\Omega,\emptyset, 0:real,1:real,+:real*real->real,-:real*real->real,*:real*real->real,\div:real*real->real,\cup:event*event->event,\cap:event*event->event,\setminus:event*event->event,=:real*real->real,=:event*event->event,\Pr, |,="
 grammar-imports,"base-10-real-numerals, latin-alphabet"
 patterns,"\Pr(_:event),\Pr(_:event|_:event),\Pr(_:event|_:event)=_:real,\Pr(_:event)=_:real"
 grammatical-complexity,type-2
 rigorous,TRUE
 facts,"$Bayes'_theorem, $law_of_total_probability, $non_negative_probability, $unit_measure, $sigma_additivity, $+inverse, $add-def, $mult-def, $*inverse"
 fact-imports,"real-number-arithmetic,finite-set-algebra"
-tactics,"rewrite, lemma, calc"
+tactics,"rewrite:fact * term * state -> state, lemma: formula * state -> state, calc : state * term -> state"
 inferential-complexity,2
 accessible-facts,TRUE
 accessible-tactics,TRUE

--- a/src/strategies/tables/RS_table_bayes.csv
+++ b/src/strategies/tables/RS_table_bayes.csv
@@ -1,7 +1,7 @@
 bayes,
 mode,"sentential"
 types,"real,event,formula,proof"
-tokens,"\forall,\Omega:event,\emptyset:event,\bar:event -> event, 0:real,1:real,+:real*real->real,-:real*real->real,*:real*real->real,\div:real*real->real,\cup:event*event->event,\cap:event*event->event,\setminus:event*event->event,=:real*real->real,=:event*event->event,\Pr:event*event->real,\Pr:event->real, |:event*event->event,=:event*event->formula,=:real*real->formula"
+tokens,"\forall,\Omega:event,\emptyset:event,\bar:event -> event, 0:real,1:real,+:real*real->real,-:real*real->real,*:real*real->real,\div:real*real->real,\cup:event*event->event,\cap:event*event->event,\setminus:event*event->event,\Pr:event*event->real,\Pr:event->real, |:event*event->event,=:event*event->formula,=:real*real->formula"
 grammar-imports,"base-10-real-numerals, latin-alphabet"
 patterns,"\Pr(_:event),\Pr(_:event|_:event),\Pr(_:event|_:event)=_:real,\Pr(_:event)=_:real"
 grammatical-complexity,type-2

--- a/src/strategies/tables/RS_table_bayes.csv
+++ b/src/strategies/tables/RS_table_bayes.csv
@@ -1,7 +1,7 @@
 bayes,
 mode,"sentential"
 types,"real,event,formula,proof"
-tokens,"\forall,\Omega,\emptyset, 0:real,1:real,+:real*real->real,-:real*real->real,*:real*real->real,\div:real*real->real,\cup:event*event->event,\cap:event*event->event,\setminus:event*event->event,=:real*real->real,=:event*event->event,\Pr, |,="
+tokens,"\forall,\Omega:event,\emptyset:event,\bar:event -> event, 0:real,1:real,+:real*real->real,-:real*real->real,*:real*real->real,\div:real*real->real,\cup:event*event->event,\cap:event*event->event,\setminus:event*event->event,=:real*real->real,=:event*event->event,\Pr:event*event->real,\Pr:event->real, |:event*event->event,=:event*event->formula,=:real*real->formula"
 grammar-imports,"base-10-real-numerals, latin-alphabet"
 patterns,"\Pr(_:event),\Pr(_:event|_:event),\Pr(_:event|_:event)=_:real,\Pr(_:event)=_:real"
 grammatical-complexity,type-2

--- a/src/strategies/tables/correspondences_bayes_contingency.csv
+++ b/src/strategies/tables/correspondences_bayes_contingency.csv
@@ -1,0 +1,8 @@
+type-event OR type-occurrence,type-cell,0.75
+token-\cup,token-SUM,0.25
+token-\cap,token-PRODUCT,0.25
+token-\Pr,tactic-get_value OR tactic-compare_values,0.5
+token-\Omega,token-last_row AND token-last_column,1
+fact-$law_of_total_probability,fact-$row_total AND fact-$column_total,1
+fact-$sigma_additivity,fact-$row_total OR fact-$column_total,0.25
+fact-$unit_measure,fact-total-1,1

--- a/src/strategies/tables/correspondences_bayes_dots.csv
+++ b/src/strategies/tables/correspondences_bayes_dots.csv
@@ -1,0 +1,9 @@
+type-real,type-arrangement, 0.25
+token-1 OR token-one,token-$dot, 1
+token-+,tactic-stack_horizontal OR tactic-stack_vertical,1
+token--,tactic-cut_horizontal OR tactic-cut_vertical OR token-cut_ell OR token-cut_square,0.5
+token-\div,tactic-cut_horizontal OR tactic-cut_vertical OR tactic-cut_diagonal,0.5
+token-=,tactic-count_equal,1
+token-*,pattern-$rectangle,1
+fact-$+-commutative,tactic-count_equal,1
+fact-$+-associative,tactic-count_equal,1

--- a/src/strategies/tables/correspondences_bayes_euler.csv
+++ b/src/strategies/tables/correspondences_bayes_euler.csv
@@ -1,0 +1,8 @@
+type-event,type-zone,1
+token-\emptyset,pattern-$shading,1
+token-\Omega OR token-all,type-diagram,1
+token-\cup,tactic-join,1
+token-\cap,tactic-distinguish,1
+token-=,type-zone,1
+token-+,tactic-join,0.25
+token--,tactic-delete,0.25

--- a/src/strategies/tables/correspondences_bayes_geometric.csv
+++ b/src/strategies/tables/correspondences_bayes_geometric.csv
@@ -1,0 +1,16 @@
+type-event,type-segment OR type-region,1
+token-\emptyset, token-$dot OR token-$segment,1
+token-0, token-$dot,0.5
+token-\Omega,type-region,0.5
+token-+,tactic-join,0.25
+token--,tactic-delete,0.25
+token-*,tactic-area,0.25
+token-\div,tactic-compare_sizes,0.5
+token-\cup,tactic-join,1
+token-\cap,tactic-distinguish,1
+token-\Pr,tactic-area OR tactic-compare_sizes,1
+token-|,tactic-compare_sizes,0.5
+token-=,type-region,1
+fact-$Bayes'_theorem,fact-$scale_independence_of_ratio,1
+fact-$law_of_total_probability OR fact-$sigma_additivity,fact-$area_additivity,1
+fact-$non_negative_probability,fact-non-negative-area,1

--- a/src/strategies/tables/correspondences_bayes_natlang.csv
+++ b/src/strategies/tables/correspondences_bayes_natlang.csv
@@ -1,0 +1,11 @@
+type-event,type-occurrence OR type-class,0.5
+token-\emptyset,token-none OR token-empty,0.5
+token-\Omega,token-universe OR token-all,0.75
+token-\cup,token-plus,0.25
+token-\setminus,token-minus,0.25
+token-\cup,token-union OR token-or,0.5
+token-\cap,token-intersection OR token-and,0.5
+token-\bar,token-complement OR token-not,0.5
+token-\Pr,token-probability,0.5
+token-|,token-given OR token-if,0.5
+tactic-calc,tactic-arithmetic_calculation,0.5

--- a/src/strategies/tables/correspondences_natlang_bayes.csv
+++ b/src/strategies/tables/correspondences_natlang_bayes.csv
@@ -3,10 +3,10 @@ token-none OR token-empty,token-\emptyset,0.75
 token-universe OR token-all,token-\Omega,0.75
 token-plus,token-\cup,0.25
 token-minus,token-\setminus,0.25
-token-times,token-\cap,0.25
-token-divided_by,token-|,0.25
 token-union OR token-or,token-\cup,1
 token-intersection OR token-and,token-\cap,1
+token-complement OR token-not,token-\bar,1
 token-probability,token-\Pr,0.75
 token-given OR token-if,token-|,1
 token-if AND (NOT token-given),token-|,-0.25
+tactic-arithmetic_calculation,tactic-calc,0.75

--- a/src/strategies/tables/correspondences_natlang_contingency.csv
+++ b/src/strategies/tables/correspondences_natlang_contingency.csv
@@ -3,6 +3,3 @@ token-union,token-SUM,0.25
 token-intersection,token-PRODUCT,0.25
 token-probability,tactic-get_value OR tactic-compare_values,0.5
 token-universe,token-last_row AND token-last_column,1
-fact-$law_of_total_probability,fact-$row_total AND fact-$column_total,1
-fact-$sigma_additivity,fact-$row_total OR fact-$column_total,0.25
-fact-$unit_measure,fact-total-1,1

--- a/src/strategies/tables/correspondences_natlang_interface.csv
+++ b/src/strategies/tables/correspondences_natlang_interface.csv
@@ -1,7 +1,0 @@
-type-class OR type-occurrence,dimension-use-X-dense OR dimension-use-Y-dense OR dimension-use-COLOUR-dense,0.25
-type-class OR type-occurrence,dimension-use-X-topological OR dimension-use-Y-topological OR dimension-use-COLOUR-topological,0.75
-type-class*class OR type-occurrence*occurrence,(dimension-use-X-topological AND dimension-use-Y-topological) OR (dimension-use-X-topological AND dimension-use-COLOUR-topological) OR (dimension-use-Y-topological AND dimension-use-COLOUR-topological),0.75
-type-number OR type-ratio OR type-fraction,dimension-use-X-metric OR dimension-use-Y-metric OR dimension-use-COLOUR-metric,0.75
-type-number OR type-ratio OR type-fraction,dimension-use-X-dense OR dimension-use-Y-dense OR dimension-use-COLOUR-dense,0.5
-token-times,(dimension-use-X-metric AND dimension-use-Y-metric) OR (dimension-use-Y-metric AND dimension-use-COLOUR-metric) OR (dimension-use-X-metric AND dimension-use-COLOUR-metric),0.25
-token-and,(dimension-use-X-topological AND dimension-use-Y-topological) OR (dimension-use-Y-topological AND dimension-use-COLOUR-topological) OR (dimension-use-X-topological AND dimension-use-COLOUR-topological),0.25

--- a/src/strategies/tables/correspondences_natlang_realarith.csv
+++ b/src/strategies/tables/correspondences_natlang_realarith.csv
@@ -3,27 +3,27 @@ type-ratio,type-real,0.9
 type-ratio,type-rational,1
 type-percentage,type-real,0.9
 token-none OR token-empty,token-0,0.25
-token-zero,grammar-import-base-10-real-numerals OR token-0,1
-token-one,grammar-import-base-10-real-numerals OR token-1,1
-token-two,grammar-import-base-10-real-numerals OR token-2,1
-token-three,grammar-import-base-10-real-numerals OR token-3,1
-token-four,grammar-import-base-10-real-numerals OR token-4,1
-token-five,grammar-import-base-10-real-numerals OR token-5,1
-token-six,grammar-import-base-10-real-numerals OR token-6,1
-token-seven,grammar-import-base-10-real-numerals OR token-7,1
-token-eight,grammar-import-base-10-real-numerals OR token-8,1
-token-nine,grammar-import-base-10-real-numerals OR token-9,1
-token-ten,grammar-import-base-10-real-numerals OR token-10,1
-token-0,grammar-import-base-10-real-numerals OR token-0,1
-token-1,grammar-import-base-10-real-numerals OR token-1,1
-token-2,grammar-import-base-10-real-numerals OR token-2,1
-token-3,grammar-import-base-10-real-numerals OR token-3,1
-token-4,grammar-import-base-10-real-numerals OR token-4,1
-token-5,grammar-import-base-10-real-numerals OR token-5,1
-token-6,grammar-import-base-10-real-numerals OR token-6,1
-token-7,grammar-import-base-10-real-numerals OR token-7,1
-token-8,grammar-import-base-10-real-numerals OR token-8,1
-token-9,grammar-import-base-10-real-numerals OR token-9,1
+token-zero,import-base-10-real-numerals OR token-0,1
+token-one,import-base-10-real-numerals OR token-1,1
+token-two,import-base-10-real-numerals OR token-2,1
+token-three,import-base-10-real-numerals OR token-3,1
+token-four,import-base-10-real-numerals OR token-4,1
+token-five,import-base-10-real-numerals OR token-5,1
+token-six,import-base-10-real-numerals OR token-6,1
+token-seven,import-base-10-real-numerals OR token-7,1
+token-eight,import-base-10-real-numerals OR token-8,1
+token-nine,import-base-10-real-numerals OR token-9,1
+token-ten,import-base-10-real-numerals OR token-10,1
+token-0,import-base-10-real-numerals OR token-0,1
+token-1,import-base-10-real-numerals OR token-1,1
+token-2,import-base-10-real-numerals OR token-2,1
+token-3,import-base-10-real-numerals OR token-3,1
+token-4,import-base-10-real-numerals OR token-4,1
+token-5,import-base-10-real-numerals OR token-5,1
+token-6,import-base-10-real-numerals OR token-6,1
+token-7,import-base-10-real-numerals OR token-7,1
+token-8,import-base-10-real-numerals OR token-8,1
+token-9,import-base-10-real-numerals OR token-9,1
 token-plus,token-+,1
 token-minus,token--,1
 token-times,token-*,1

--- a/src/util/type.sml
+++ b/src/util/type.sml
@@ -50,6 +50,7 @@ fun unify (Ground s) (Ground s') = (s = s')
   | unify (Constructor(s,t)) (Constructor(s',t')) = (s = s') andalso (unify t t')
   | unify _ _ = false;
 
+(*A lexicographic order for types, to use in dictionaries*)
 fun compare (Ground s, Ground s') = String.compare (s,s')
   | compare (Ground _, _) = LESS
   | compare (_, Ground _) = GREATER

--- a/src/util/type.sml
+++ b/src/util/type.sml
@@ -1,0 +1,151 @@
+import "util.logging";
+
+structure Type =
+struct
+
+(*
+To properly handle all the different tokens, it can be useful to give them
+'types'. We support a simple subset of the Standard ML type language: ground
+types, variables, pairs, functions, and unary type constructors. Variables are
+denoted by a preceding quote (e.g., 'a).
+For example,
+    ('a list * int) tree -> (('a * int) -> int) -> int
+would parse to
+    Function(
+        Constructor(
+            "tree",
+            Pair(
+                Constructor("list", Var "a"),
+                Ground "int")),
+        Function(
+            Function(
+                Pair(Var "a", Ground "int"),
+                Ground "int"),
+            Ground "int"))
+Note that * and -> have equal precedence and are right associative, so
+    'a * int -> int
+parses differently to
+    ('a * int) -> int
+The first is equivalent to 'a * (int -> int). This is a deviation from the SML
+standard, but is much easier to parse.
+*)
+datatype T = Ground of string
+           | Var of string
+           | Pair of T * T
+           | Function of T * T
+           | Constructor of string * T;
+
+fun occurs x (Ground _) = false
+  | occurs x (Var y) = (x = y)
+  | occurs x (Pair (s,t)) = (occurs x s orelse occurs x t)
+  | occurs x (Function (s,t)) = (occurs x s orelse occurs x t)
+  | occurs x (Constructor (_,t)) = occurs x t;
+
+fun unify (Ground s) (Ground s') = (s = s')
+  | unify (Var x) (Var y) = true
+  | unify (Var x) t = not (occurs x t)
+  | unify t (Var x) = not (occurs x t)
+  | unify (Pair(s,t)) (Pair(s',t')) = (unify s s') andalso (unify t t')
+  | unify (Function(s,t)) (Function(s',t')) = (unify s s') andalso (unify t t')
+  | unify (Constructor(s,t)) (Constructor(s',t')) = (s = s') andalso (unify t t')
+  | unify _ _ = false;
+
+fun compare (Ground s, Ground s') = String.compare (s,s')
+  | compare (Ground _, _) = LESS
+  | compare (_, Ground _) = GREATER
+  | compare (Var s, Var s') = String.compare (s,s')
+  | compare (Var _, _) = LESS
+  | compare (_, Var _) = GREATER
+  | compare (Pair (t,u), Pair (t',u')) = let val c = compare (t,t')
+                                         in if c = EQUAL then compare (u,u') else c
+                                         end
+  | compare (Pair _, _) = LESS
+  | compare (_, Pair _) = GREATER
+  | compare (Function (t,u), Function (t',u')) = let val c = compare (t,t')
+                                                 in if c = EQUAL then compare (u,u') else c
+                                                 end
+  | compare (Function _, _) = LESS
+  | compare (_, Function _) = GREATER
+  | compare (Constructor (s,t), Constructor (s',t')) = let val c = String.compare (s,s')
+                                                       in if c = EQUAL then compare (t,t') else c
+                                                       end
+  ;
+
+fun typeToString (Ground s) = s
+  | typeToString (Var s) = "'" ^ s
+  | typeToString (Pair (t,u)) = "(" ^ (typeToString t) ^ " * " ^ (typeToString u) ^ ")"
+  | typeToString (Function (t, (Function (u,v)))) =
+    (typeToString t) ^ " -> (" ^ (typeToString (Function (u,v))) ^ ")"
+  | typeToString (Function (t,u)) = (typeToString t) ^ " -> " ^ (typeToString u)
+  | typeToString (Constructor (s,t)) = (typeToString t) ^ " " ^ s;
+
+fun typeDebugString (Ground s) = "Ground \"" ^ s ^ "\""
+  | typeDebugString (Var s) = "Var \"" ^ s ^ "\""
+  | typeDebugString (Pair (t,u)) = "Pair(" ^ (typeDebugString t) ^ ", "
+                                 ^ (typeDebugString u) ^ ")"
+  | typeDebugString (Function (t,u)) = "Function(" ^ (typeDebugString t) ^ ", "
+                                     ^ (typeDebugString u) ^ ")"
+  | typeDebugString (Constructor (s,t)) = "Constructor(\"" ^ s ^ "\", " ^ (typeDebugString t) ^ ")";
+
+fun vartype str =
+    let
+        fun readExactly [] _ = true
+          | readExactly _ [] = false
+          | readExactly (x::xs) (c::cs) =
+            if x = c then readExactly xs cs
+            else false;
+        fun collectUntil b [] xs = (String.implode (List.rev xs), [])
+          | collectUntil b (c::cs) xs =
+            if (b c) then (String.implode (List.rev xs), c::cs)
+            else collectUntil b cs (c::xs);
+        fun isInvalid c = not (Char.isAlpha c);
+        fun typeTokens [] out = List.rev out
+          | typeTokens (c::cs) out =
+            if c = #"'" then let val (tok, cs') = collectUntil (isInvalid) cs []
+                             in typeTokens cs' ((Var tok)::out) end
+            else if c = #"*" then typeTokens cs ((Ground "*")::out)
+            else if readExactly [#"-", #">"] (c::cs) then
+                typeTokens (List.drop (cs, 1)) ((Ground "->")::out)
+            else if Char.isSpace c then typeTokens cs out
+            else if c = #"(" then typeTokens cs ((Ground "(")::out)
+            else if c = #")" then typeTokens cs ((Ground ")")::out)
+            else let val (tok, cs') = collectUntil (isInvalid) (c::cs) []
+                 in typeTokens cs' ((Ground tok)::out) end;
+
+        fun toCloseParen [] _ = raise Match
+          | toCloseParen ((Ground "(")::ys) xs =
+            let
+                val (innerToks, rest) = toCloseParen ys [];
+                val innerType = readType innerToks
+            in
+                toCloseParen rest (innerType::xs)
+            end
+          | toCloseParen ((Ground ")")::ys) xs = (List.rev xs, ys)
+          | toCloseParen (c::cs) xs = toCloseParen cs (c::xs)
+        and readType [] = raise Match
+          | readType [x] = x
+          | readType ((Ground "(")::cs) =
+            let val (ins, outs) = toCloseParen cs []
+            in readType ((readType ins)::outs) end
+          | readType (c::(Ground "*")::cs) =
+            let val left = c;
+                val right = readType cs;
+            in Pair (left, right) end
+          | readType (c::(Ground "->")::cs) =
+            let val left = c;
+                val right = readType cs;
+            in Function (left, right) end
+          | readType (x::(Ground y)::cs) = readType ((Constructor (y, x))::cs)
+          | readType stuff =
+            let
+                val _ = Logging.write((listToString typeToString stuff) ^ "\n");
+            in raise Match end;
+
+        val chars = String.explode str;
+        val tokens = typeTokens chars [];
+        val finalType = readType tokens;
+    in
+        finalType
+    end;
+
+  end;


### PR DESCRIPTION
type property was changed from string to a datatype with Simple, Typed, and Attr constructors, which allow us to add types to tokens and attributes to types.

Then, instead of comparing properties with string equality, I use a more sophisticated matching function which matches untyped things with typed things, and typed things match with each other if and only if they unify (there are type variables!). It's nothing too sophisticated, but it enables more structure in tables, where we can classify tokens according to types and we can add attributes to types (such as iconic, gestalt, text, etc.). Property matches does not affect previous matching of untyped things.

Property matching is used for finding whether a correspondence holds between a Q and an RS.