### PR TITLE
Improve property reading reliability

### DIFF
--- a/src/main.sml
+++ b/src/main.sml
@@ -9,8 +9,6 @@ import "strategies.representation_selection";
 *)
 Logging.enable ();
 
-exception ArgumentError of int;
-
 structure RepSelect = RepresentationSelection;
 
 fun filesMatchingPrefix dir prefix =

--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -1,6 +1,7 @@
 import "util.set";
 import "util.dictionary";
 import "util.formula";
+import "util.parser";
 
 import "strategies.properties.property";
 import "strategies.properties.importance";
@@ -133,24 +134,7 @@ fun toString (q, r, s) =
 
 fun fromString s =
     let
-        fun removeParens s =
-            let
-                fun charIs c = fn x => x = c
-                fun flipAndDropIf p [] = raise Match
-                  | flipAndDropIf p xs = case List.rev xs of
-                                             (y::ys) => if p y then ys
-                                                        else raise Match
-                                           | [] => [];
-                val chars = String.explode s;
-                val dropped = flipAndDropIf
-                                  (charIs #"(") (flipAndDropIf
-                                                     (charIs #")") chars)
-                              handle Match => chars;
-                val s' = String.implode dropped;
-            in
-                s'
-            end;
-        val parts = String.tokens (fn c => c = #",") (removeParens s);
+        val parts = Parser.splitStrip "," (Parser.removeParens s);
         val (leftString, rightString, valString) =
             case parts of
                 [l, r, v] => (l, r, v)

--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -147,6 +147,8 @@ fun fromString s =
         val read = F.fromString Property.fromString;
     in
         (read leftString, read rightString, realFromString valString)
-    end;
+    end
+    handle F.ParseError => raise ParseError
+         | Kind.KindError => raise ParseError;
 
 end;

--- a/src/strategies/properties/kind.sml
+++ b/src/strategies/properties/kind.sml
@@ -1,0 +1,134 @@
+signature KIND =
+sig
+    exception KindError;
+    eqtype kind;
+
+    val Token : kind;
+    val Type : kind;
+    val Fact : kind;
+    val Tactic : kind;
+    val Pattern : kind;
+    val Quantifier : kind;
+    val Mode : kind;
+    val Import : kind;
+    val Rigorous : kind;
+    val LogicalOrder : kind;
+    val ErrorAllowed : kind;
+    val DimensionUse : kind;
+    val GrammaticalDimensionality : kind;
+    val GrammaticalGranularity : kind;
+    val GrammaticalComplexity : kind;
+    val InferentialComplexity : kind;
+    val StandardAccessibilityManipulations : kind;
+    val AccessibleGrammaticalConstructors : kind;
+    val AccessibleTactics : kind;
+    val AccessibleFacts : kind;
+    val KnowledgeManipulationSystem : kind;
+    val EditableExternalMemory : kind;
+    val BranchingFactor : kind;
+    val SolutionDepth : kind;
+    val LimitConstructionSize : kind;
+    val ParseGenerateStructures : kind;
+    val ParseGenerateMapping : kind;
+    val PrDistinctStateChange : kind;
+    val PrValidStateChange : kind;
+    val NumTokens : kind;
+    val NumDistinctTokens : kind;
+    val NumStatements : kind;
+
+    val allKinds : kind list;
+
+    val toString : kind -> string;
+    val fromString : string -> kind;
+
+    val compare : kind * kind -> order;
+
+end;
+
+structure Kind :> KIND =
+struct
+
+exception KindError;
+type kind = string;
+
+val Token = "token";
+val Type = "type";
+val Fact = "fact";
+val Tactic = "tactic";
+val Pattern = "pattern";
+val Quantifier = "quantifier";
+val Mode = "mode";
+val Import = "import";
+val Rigorous = "rigorous";
+val LogicalOrder = "logical_order";
+val ErrorAllowed = "error_allowed";
+val DimensionUse = "physical_dimension_use";
+val GrammaticalDimensionality = "grammatical_dimensionality";
+val GrammaticalGranularity = "grammatical_granularity";
+val GrammaticalComplexity = "grammatical_complexity";
+val InferentialComplexity = "inferential_complexity";
+val StandardAccessibilityManipulations = "standard_accessibility_manipulation";
+val AccessibleGrammaticalConstructors = "accessible_grammatical_constructors";
+val AccessibleTactics = "accessible_tactics";
+val AccessibleFacts = "accessible_facts";
+val KnowledgeManipulationSystem = "knowledge_manipulation_system";
+val EditableExternalMemory = "editable_external_memory";
+val BranchingFactor = "mean_branching_factor";
+val SolutionDepth = "mean_solution_depth";
+val LimitConstructionSize = "limit_construction_size";
+val ParseGenerateStructures = "parse_generate_structures";
+val ParseGenerateMapping = "parse_generate_mapping";
+val PrDistinctStateChange = "pr_distinct_state_change";
+val PrValidStateChange = "pr_valid_state_change";
+val NumTokens = "num_tokens";
+val NumDistinctTokens = "num_distinct_tokens";
+val NumStatements = "num_statements";
+
+structure StringSet = Set(struct
+                           type t = string;
+                           val compare = String.compare;
+                           val fmt = fn s => s;
+                           end);
+
+val allKinds' = StringSet.fromList [Token,
+                                    Type,
+                                    Fact,
+                                    Tactic,
+                                    Pattern,
+                                    Quantifier,
+                                    Mode,
+                                    Import,
+                                    Rigorous,
+                                    LogicalOrder,
+                                    ErrorAllowed,
+                                    DimensionUse,
+                                    GrammaticalDimensionality,
+                                    GrammaticalGranularity,
+                                    GrammaticalComplexity,
+                                    InferentialComplexity,
+                                    StandardAccessibilityManipulations,
+                                    AccessibleGrammaticalConstructors,
+                                    AccessibleTactics,
+                                    AccessibleFacts,
+                                    KnowledgeManipulationSystem,
+                                    EditableExternalMemory,
+                                    BranchingFactor,
+                                    SolutionDepth,
+                                    LimitConstructionSize,
+                                    ParseGenerateStructures,
+                                    ParseGenerateMapping,
+                                    PrDistinctStateChange,
+                                    PrValidStateChange,
+                                    NumTokens,
+                                    NumDistinctTokens
+                                   ];
+val allKinds = StringSet.toList allKinds';
+
+fun toString k = k;
+
+fun fromString k = if StringSet.contains allKinds' k then k
+                   else raise KindError;
+
+fun compare (k, k') = String.compare (k, k');
+
+end;

--- a/src/strategies/properties/readers.sml
+++ b/src/strategies/properties/readers.sml
@@ -14,6 +14,7 @@ we would generate the properties
     op-+, op--, op-*, op-\sqrt, sentential, logic-power-2
 *)
 
+import "util.parser";
 import "strategies.properties.importance";
 import "strategies.properties.tables";
 
@@ -32,10 +33,10 @@ fun number str =
 fun label str = [Property.Label str];
 
 fun collection str = if str = "NONE" then []
-                     else map (Property.Label o stringTrim) (String.tokens (fn c => c = #",") str);
+                     else map Property.Label (Parser.splitStrip "," str);
 
 fun collection' str = if str = "NONE" then []
-                    else map (stringTrim) (String.tokens (fn c => c = #",") str);
+                    else Parser.splitStrip "," str;
 fun dimension str =
     let
         fun parseDimProps s = if s = "{}" then []
@@ -46,11 +47,11 @@ fun dimension str =
                                     | dropEnds (x::xs) = List.rev (List.tl (List.rev xs));
                                   val s' = String.implode (dropEnds (String.explode s));
                               in
-                                  map stringTrim (String.tokens (fn c => c = #";") s')
+                                  Parser.splitStrip ";" s'
                               end;
         fun createPairs dimval =
             let
-                val parts = map stringTrim (String.tokens (fn c => c = #":") dimval);
+                val parts = Parser.splitStrip ":" dimval;
             in
                 case parts of
                     [x, y] => (x, parseDimProps y)

--- a/src/strategies/properties/tables.sml
+++ b/src/strategies/properties/tables.sml
@@ -64,17 +64,13 @@ structure CSVLiberal = CSVIO(struct val delimiters = [#","];
 type qgenerator = (string -> Property.value list) * Property.kind * Importance.importance;
 type rsgenerator = (string -> Property.value list) * Property.kind;
 
-datatype CorrTree = Prop of string
-                  | Neg of CorrTree
-                  | Conj of CorrTree * CorrTree
-                  | Disj of CorrTree * CorrTree;
-
-
 fun readCorrespondence q r s =
     let
         val rowString = q ^ "," ^ r ^ "," ^ s;
     in
         [Correspondence.fromString rowString]
+        handle Correspondence.ParseError =>
+               raise TableError ("Failed to parse row: " ^ rowString ^ "\n")
     end;
 
 fun loadCorrespondenceTable filename =
@@ -87,7 +83,7 @@ fun loadCorrespondenceTable filename =
         val csvFile = CSVLiberal.openIn filename;
         val csvData = CSVLiberal.input csvFile;
     in
-        List.foldr (fn (r, xs) => (makeRow r) @ xs) [] csvData
+        flatmap makeRow csvData
     end
     handle IO.Io e => (Logging.error ("ERROR: File '" ^ filename ^ "' could not be loaded\n");
                        raise (IO.Io e))

--- a/src/strategies/properties/tables.sml
+++ b/src/strategies/properties/tables.sml
@@ -6,6 +6,7 @@ import "util.csv";
 import "strategies.properties.property";
 import "strategies.properties.importance";
 import "strategies.properties.correspondence";
+import "strategies.properties.readers";
 
 signature PROPERTYTABLES =
 sig
@@ -13,8 +14,8 @@ sig
 
     structure FileDict : DICTIONARY;
 
-    type qgenerator = (string -> Property.value list) * Property.kind * Importance.importance;
-    type rsgenerator = (string -> Property.value list) * Property.kind;
+    type qgenerator = (string -> Property.value list) * Kind.kind * Importance.importance;
+    type rsgenerator = (string -> Property.value list) * Kind.kind;
 
     val loadCorrespondenceTable : string -> Correspondence.correspondence list;
     val loadQuestionTable : string -> (FileDict.k, QPropertySet.t QPropertySet.set) FileDict.dict;
@@ -61,8 +62,8 @@ structure CSVLiberal = CSVIO(struct val delimiters = [#","];
                                     val newlines = ["\r", "\n", "\r\n"];
                              end);
 
-type qgenerator = (string -> Property.value list) * Property.kind * Importance.importance;
-type rsgenerator = (string -> Property.value list) * Property.kind;
+type qgenerator = (string -> Property.value list) * Kind.kind * Importance.importance;
+type rsgenerator = (string -> Property.value list) * Kind.kind;
 
 fun readCorrespondence q r s =
     let
@@ -173,16 +174,18 @@ fun loadQuestionTable filename = let
             val (valparser, keypre, defaultImportance) =
                 case (findQGenerator key) of
                     SOME kt => kt
-                  | NONE => ((fn s => [Property.Label s]),Property.kindOfString (key ), Importance.Low);
+                  | NONE => ((fn s => [Property.Label s]), (Kind.fromString key), Importance.Low);
             val importance = case overrideImportance of
                                     NONE => defaultImportance
                                   | SOME i => i;
             fun makeProp v = QProperty.fromPair
-                                 (Property.fromKindValuePair ( keypre, v),
+                                 (Property.fromKindValuePair (keypre, v),
                                   importance);
         in
             qset' (map makeProp (valparser args))
-        end;
+        end
+        handle Kind.KindError =>
+               raise TableError ("Unable to determine kind of " ^ key);
 in
     filedict' (loadQorRSPropertiesFromFile sets parseRow genProps filename)
 end;
@@ -197,11 +200,13 @@ fun loadRepresentationTable filename = let
                                     handle GenDict.KeyError => NONE;
             val (valparser, keypre) = case (findRSGenerator key) of
                                           SOME kt => kt
-                                        | NONE => ((fn s => [Property.Label s]), Property.kindOfString (key ));
+                                        | NONE => raise TableError ("Unknown property kind: " ^ key);
             fun makeProp v = Property.fromKindValuePair ( keypre, v);
         in
             set' (map makeProp (valparser args))
-        end;
+        end
+        handle PropertyReader.ReadError (r, v) =>
+               raise TableError ("Unable to read " ^ r ^ ": " ^ v);
 in
     filedict' (loadQorRSPropertiesFromFile sets parseRow genProps filename)
 end;

--- a/src/strategies/representation_selection.sml
+++ b/src/strategies/representation_selection.sml
@@ -16,6 +16,10 @@ structure FileDict = PropertyTables.FileDict;
 
 (* Read in some data *)
 
+val _ = registerPropertyReaders
+            PropertyTables.setQGenerators
+            PropertyTables.setRSGenerators;
+
 val propertyTableRep' = ref (FileDict.empty ());
 val correspondingTable' = ref [];
 val propertyTableQ' = ref (FileDict.empty ());

--- a/src/util/configuration.sml
+++ b/src/util/configuration.sml
@@ -125,7 +125,7 @@ fun getArgBool args x =
 
 fun readQuestion qrs =
     let val separator = ":"
-    in case (Parser.splitStringOn separator qrs) of
+    in case (Parser.splitOn separator qrs) of
            [q, rs] => (q, rs)
          | _ => raise ArgumentError qrs
     end;
@@ -144,9 +144,9 @@ fun configFromCommandLine rawArgs =
         val args = readCommandLineArguments argspec rawArgs;
         val (q, rs) = readQuestion (getArgument args "question:rs");
         val limit = readLimit (getArgument args "suggestion limit");
-        val rss = flatmap (Parser.splitStringOn ",")
+        val rss = flatmap (Parser.splitStrip ",")
                           (getArguments args "potential RSs");
-        val corrFiles = flatmap (Parser.splitStringOn ",")
+        val corrFiles = flatmap (Parser.splitStrip ",")
                                 (getArguments args "correspondence files");
     in
         ((q, rs), limit, rss, corrFiles)

--- a/src/util/formula.sml
+++ b/src/util/formula.sml
@@ -248,6 +248,9 @@ fun fromString builder s =
 
     in
         ((map builder) o normalise o parse o tokenize) s
-    end;
+    end
+    handle Parser.ParseError => (Logging.error
+                                     ("Failed to parse formula \"" ^ s ^ "\"\n");
+                                 raise ParseError);
 
 end;

--- a/src/util/robinlib.sml
+++ b/src/util/robinlib.sml
@@ -27,7 +27,6 @@ sig
     val takeWhile : ('a -> bool) -> 'a list -> 'a list;
     val listToString : ('a -> string) -> 'a list -> string;
     val lookaheadN : (TextIO.instream *  int) -> string;
-    val stringTrim : string -> string;
     val spread : ('a -> 'b) -> ('a * 'a) -> ('b * 'b);
     val flip : ('a * 'b) -> ('b * 'a);
     val cmpJoin : ('a * 'a -> order) -> ('b * 'b -> order) -> (('a * 'b) * ('a * 'b)) -> order;
@@ -153,20 +152,6 @@ fun lookaheadN (istr, count) =
         val (lookahead, newstream) = TextIO.StreamIO.inputN(oldstream, count)
     in
         lookahead
-    end;
-
-fun stringTrim str =
-    let
-        val chars = String.explode str;
-        val remainingChars = List.rev
-                                 (dropWhile
-                                      Char.isSpace
-                                      (List.rev
-                                           (dropWhile
-                                                Char.isSpace
-                                                chars)));
-    in
-        String.implode remainingChars
     end;
 
 fun spread f (a, b) = (f a, f b);

--- a/tables/RS_table_1dimps.csv
+++ b/tables/RS_table_1dimps.csv
@@ -1,6 +1,6 @@
 P-space_diagrams,
 mode,geometric
-logical-order,0
+logical_order,0
 types,"trial_line,outcome_segment,probability_segment,real,label"
 tokens,"$trial_line,$outcome_segment,$probability_segment"
 patterns,"$overlap,$empty_segment"
@@ -12,7 +12,7 @@ fact_imports,NONE
 tactics,"draw_trial_line,draw_outcome_segment,draw_and,draw_or,draw_conditional,measure_length,compare_lengths"
 inferential_complexity,1
 standard_accessibility_manipulations,""
-accessible_fact,FALSE
+accessible_facts,FALSE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,TRUE
 physical_dimension_use,"X:{grammatical;dense;metric;topological}, Y:{grammatical;inferential}, colour:{}"

--- a/tables/RS_table_algebra.csv
+++ b/tables/RS_table_algebra.csv
@@ -13,7 +13,7 @@ rigorous,TRUE
 fact_imports,NONE
 tactics,"rewrite,lemma,calc,induction"
 inferential_complexity,2
-accessible_fact,TRUE
+accessible_facts,TRUE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,FALSE
 physical_dimension_use,"X:{grammatical;inferential}, Y:{inferential},  colour:{}"

--- a/tables/RS_table_bayes.csv
+++ b/tables/RS_table_bayes.csv
@@ -10,7 +10,7 @@ facts,"$Bayes'_theorem, $law_of_total_probability, $non_negative_probability, $u
 fact_imports,"real-number-arithmetic,finite-set-algebra"
 tactics,"rewrite:fact * term * state -> state, lemma: formula * state -> state, calc : state * term -> state"
 inferential_complexity,2
-accessible_fact,TRUE
+accessible_facts,TRUE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,FALSE
 physical_dimension_use,"X:{grammatical;inferential}, Y:{inferential}, colour:{}"

--- a/tables/RS_table_contingency.csv
+++ b/tables/RS_table_contingency.csv
@@ -12,10 +12,10 @@ fact_imports,NONE
 tactics,"add_value, add_formula, get_value, compare_values"
 inferential_complexity,2
 standard_accessibility_manipulations,"add_row, add_column, copy, paste"
-accessible_fact,FALSE
+accessible_facts,FALSE
 accessible_tactics,FALSE
 accessible_grammatical_constructors,TRUE
-editable-external-memory,TRUE
+editable_external_memory,TRUE
 physical_dimension_use,"X:{grammatical;topological}, Y:{grammatical;topological}, colour:{}"
 grammatical_dimensionality,2
 grammatical_granularity,discrete

--- a/tables/RS_table_dots.csv
+++ b/tables/RS_table_dots.csv
@@ -11,7 +11,7 @@ rigorous,TRUE
 tactics,"stack_horizontal,stack_vertical,cut_horizontal,cut_vertical,cut_diagonal,cut_ell,cut_square,count_equal,count_more,count_less,constructive_omega_rule"
 inferential_complexity,0
 standard_accessibility_manipulations,"add,stack,cut,count,undo"
-accessible_fact,TRUE
+accessible_facts,TRUE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,TRUE
 physical_dimension_use,"X:{grammatical;inferential},Y:{grammatical;inferential},colour:{}"

--- a/tables/RS_table_euler.csv
+++ b/tables/RS_table_euler.csv
@@ -11,7 +11,7 @@ fact_imports,NONE
 tactics,"add_contour,remove_contour,add_shaded_zone,remove_shaded_zone,remove_shading_from_zone,observe_inclusion,observe_intersection,observe_union"
 inferential_complexity,4
 standard_accessibility_manipulations,""
-accessible_fact,FALSE
+accessible_facts,FALSE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,TRUE
 physical_dimension_use,"X:{grammatical;dense;topological}, Y:{grammatical;dense;topological;inferential}, colour:{}"

--- a/tables/RS_table_eventtrees.csv
+++ b/tables/RS_table_eventtrees.csv
@@ -11,7 +11,7 @@ fact_imports,""
 tactics,"add_variable_children, reroot, calculate_node_pr, compare_values"
 inferential_complexity,1
 standard_accessibility_manipulations,"undo"
-accessible_fact,FALSE
+accessible_facts,FALSE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,FALSE
 physical_dimension_use,"X:{grammatical;topological}, Y:{grammatical;topological;inferential}, colour:{}"

--- a/tables/RS_table_geometric.csv
+++ b/tables/RS_table_geometric.csv
@@ -5,13 +5,13 @@ tokens,"$dot,$line,$segment"
 grammar_imports,"latin_alphabet"
 grammatical_complexity,type-3
 rigorous,TRUE
-knowledge-manipulation-system,FALSE
+knowledge_manipulation_system,FALSE
 facts,"$scale_independence_of_ratio,$area_additivity,$non_negative_area"
 fact_imports,NONE
 tactics,"draw_point,draw_line,draw_segment,draw_polygon,delete,distinguish,join,distance,area,change_label,compare_sizes,focus_on_region,observe"
 inferential_complexity,1
 standard_accessibility_manipulations,change_label
-accessible_fact,FALSE
+accessible_facts,FALSE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,TRUE
 physical_dimension_use,"X:{grammatical;dense;metric;topological}, Y:{grammatical;dense;metric;topological}, colour:{}"

--- a/tables/RS_table_graphs.csv
+++ b/tables/RS_table_graphs.csv
@@ -10,7 +10,7 @@ facts,"$count_invariant"
 fact_imports,NONE
 tactics,"edge_add,edge_remove,edge_count,vertex_add,vertex_remove,vertex_count,join_graphs,remove_graph,constructive_omega_rule"
 inferential_complexity,0
-accessible_fact,TRUE
+accessible_facts,TRUE
 accessible_tactics,TRUE
 accessible_grammatical_constructors,TRUE
 physical_dimension_use,"X:{grammatical;inferential},Y:{grammatical;inferential},colour:{}"

--- a/tables/correspondences_natlang_euler.csv
+++ b/tables/correspondences_natlang_euler.csv
@@ -7,4 +7,4 @@ token-union OR token-or,tactic-observe_union,0.75
 token-intersection OR token-and,tactic-observe_intersection,0.75
 token-given OR token-if,tactic-observe_inclusion,0.75
 token-if AND (NOT token-given),tactic-observe_inclusion,-0.25
-token-equals,relation-same_zone,0.5
+token-equals,tactic-same_zone,0.5


### PR DESCRIPTION
This pull request does two main things:

- First, the parsing structure gets many new functions, which are widely used.
- Second, it makes "kinds" their own thing. The universe of kinds is now fixed: if they are not in the table, they are not OK. I also took this chance to rename a few kinds.

The `PropertyReader.collection` function has been replaced with `PropertyReader.listOf`, which takes another `propertyreader` as an argument. Thus rather than only allowing a list of labels, you can have a list of anything you like.

We also introduce a couple of helpful QProperty functions: `kindOf` and `importanceOf`.