### PR TITLE
Type correspondences

### DIFF
--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -199,22 +199,24 @@ fun allCorrespondenceMatches corrs qProps rProps =
     end;
 
 
-
-structure F = Correspondence.F;
-exception skipProp;
-fun typeCorrespondences corrs qProps =
-    let fun tCorrs q =
-            let val p = QProperty.withoutImportance q
-                val t = Property.getTypeOfValue p handle Property.NoAttribute _ => raise skipProp
-                val singletonT = PropertySet.fromList [Property.fromKindValueAttributes (Kind.Type, Property.Type t, [])]
-                val singletonP = PropertySet.fromList [p]
-                val g = QProperty.logGravity q handle Property.NoAttribute _ => 0.0
-                fun mkCorrs [] = []
-                  | mkCorrs (((x,y,s),i)::L) =
-                      if PropertySet.isEmpty (Correspondence.leftMatches singletonT (x,y,s))
-                      then (if PropertySet.isEmpty (Correspondence.leftMatches singletonP (x,y,s)) then mkCorrs L else raise skipProp)
-                      else ((F.Atom p, F.Atom (Property.fromKindValueAttributes (Kind.Dummy, Property.Label ("\"" ^ F.toString Property.toString y ^ "\""), [])),s), i*g) :: mkCorrs L
-            in mkCorrs corrs
-            end handle skipProp => [] (* This is the hackiest thing ever, but it should take care of cases when there is already a correspondence for the property, so we don't need to add it from its type *)
-    in List.concat (QPropertySet.map tCorrs qProps)
-    end;
+local
+  structure F = Correspondence.F;
+  exception skipProp;
+in
+  fun typeCorrespondences corrs qProps =
+      let fun tCorrs q =
+              let val p = QProperty.withoutImportance q
+                  val t = Property.getTypeOfValue p handle Property.NoAttribute _ => raise skipProp
+                  val singletonT = PropertySet.fromList [Property.fromKindValueAttributes (Kind.Type, Property.Type t, [])]
+                  val singletonP = PropertySet.fromList [p]
+                  val g = QProperty.logGravity q handle Property.NoAttribute _ => 0.0
+                  fun mkCorrs [] = []
+                    | mkCorrs (((x,y,s),i)::L) =
+                        if PropertySet.isEmpty (Correspondence.leftMatches singletonT (x,y,s))
+                        then (if PropertySet.isEmpty (Correspondence.leftMatches singletonP (x,y,s)) then mkCorrs L else raise skipProp)
+                        else ((F.Atom p, F.Atom (Property.fromKindValueAttributes (Kind.Dummy, Property.Label ("\"" ^ F.toString Property.toString y ^ "\""), [])),s), i*g) :: mkCorrs L
+              in mkCorrs corrs
+              end handle skipProp => [] (* This is the hackiest thing ever, but it should take care of cases when there is already a correspondence for the property, so we don't need to add it from its type *)
+      in List.concat (QPropertySet.map tCorrs qProps)
+      end;
+end;

--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -145,7 +145,8 @@ fun liftImportances qs (l, _, _) =
                                 qFind
                                 qs l;
         val allImportances = QPropertySet.map
-                                 (fn q => QProperty.logGravity q handle Property.NoAttribute _ => QProperty.importanceOf q) matchedQProps;
+                                 (fn q => QProperty.logGravity q handle Property.NoAttribute _ => QProperty.importanceOf q)
+                                 matchedQProps;
     in
         allImportances
     end;

--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -145,7 +145,8 @@ fun liftImportances qs (l, _, _) =
                                 qFind
                                 qs l;
         val allImportances = QPropertySet.map
-                                 (fn q => #2 (QProperty.toPair q)) matchedQProps;
+                                 (fn q => QProperty.logGravity q handle Property.NoAttribute _ => QProperty.importanceOf q)
+                                 matchedQProps;
     in
         allImportances
     end;
@@ -205,7 +206,7 @@ fun typeCorrespondences corrs qProps =
     let fun tCorrs q =
             let val p = QProperty.withoutImportance q
                 val t = Property.getTypeOfValue p handle Property.NoAttribute _ => raise skipProp
-                val singletonT = PropertySet.fromList [(Property.fromKindValueAttributes (Kind.Type, Property.Type t, []))]
+                val singletonT = PropertySet.fromList [Property.fromKindValueAttributes (Kind.Type, Property.Type t, [])]
                 val singletonP = PropertySet.fromList [p]
                 val g = QProperty.logGravity q handle Property.NoAttribute _ => 0.0
                 fun mkCorrs [] = []

--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -145,7 +145,7 @@ fun liftImportances qs (l, _, _) =
                                 qFind
                                 qs l;
         val allImportances = QPropertySet.map
-                                 (fn q => #2 (QProperty.toPair q)) matchedQProps;
+                                 (fn q => QProperty.logGravity q handle Property.NoAttribute _ => QProperty.importanceOf q) matchedQProps;
     in
         allImportances
     end;
@@ -205,7 +205,7 @@ fun typeCorrespondences corrs qProps =
     let fun tCorrs q =
             let val p = QProperty.withoutImportance q
                 val t = Property.getTypeOfValue p handle Property.NoAttribute _ => raise skipProp
-                val singletonT = PropertySet.fromList [(Property.fromKindValueAttributes (Kind.Type, Property.Type t, []))]
+                val singletonT = PropertySet.fromList [Property.fromKindValueAttributes (Kind.Type, Property.Type t, [])]
                 val singletonP = PropertySet.fromList [p]
                 val g = QProperty.logGravity q handle Property.NoAttribute _ => 0.0
                 fun mkCorrs [] = []

--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -11,6 +11,7 @@ sig
 
     exception ParseError
 
+    structure F : FORMULA;
     type 'a corrformula;
     type correspondence = Property.property corrformula * Property.property corrformula * real;
 
@@ -183,7 +184,6 @@ fun fromString s =
 
 end;
 
-
 fun allCorrespondenceMatches corrs qProps rProps =
     let
         fun alreadyCorr cs c = List.exists (Correspondence.matchingProperties c) cs;
@@ -195,4 +195,25 @@ fun allCorrespondenceMatches corrs qProps rProps =
                                         identities;
     in
         newIdentities @ baseCorrs
+    end;
+
+
+
+structure F = Correspondence.F;
+exception skipProp;
+fun typeCorrespondences corrs qProps =
+    let fun tCorrs q =
+            let val (p,i') = QProperty.toPair q
+                val t = Property.getTypeOfValue p handle Property.NoAttribute _ => raise skipProp
+                val singletonT = PropertySet.fromList [(Property.fromKindValueAttributes (Kind.Type, Property.Type t, []))]
+                val singletonP = PropertySet.fromList [p]
+                val n = #2 (Property.getNumFunction "occurrences" p) handle Property.NoAttribute _ => 0.0
+                fun mkCorrs [] = []
+                  | mkCorrs (((x,y,s),i)::L) =
+                      if PropertySet.isEmpty (Correspondence.leftMatches singletonT (x,y,s))
+                      then (if PropertySet.isEmpty (Correspondence.leftMatches singletonP (x,y,s)) then mkCorrs L else raise skipProp)
+                      else ((F.Atom p, F.Atom (Property.fromKindValueAttributes (Kind.Dummy, Property.Label ("\"" ^ F.toString Property.toString y ^ "\""), [])),s), i*i'*(1.0 + Math.ln(n + 1.0)/Math.ln(2.0))) :: mkCorrs L
+            in mkCorrs corrs
+            end handle skipProp => [] (* This is the hackiest thing ever, but it should take care of cases when there is already a correspondence for the property, so we don't need to add it from its type *)
+    in List.concat (QPropertySet.map tCorrs qProps)
     end;

--- a/src/strategies/properties/correspondence.sml
+++ b/src/strategies/properties/correspondence.sml
@@ -203,16 +203,16 @@ structure F = Correspondence.F;
 exception skipProp;
 fun typeCorrespondences corrs qProps =
     let fun tCorrs q =
-            let val (p,i') = QProperty.toPair q
+            let val p = QProperty.withoutImportance q
                 val t = Property.getTypeOfValue p handle Property.NoAttribute _ => raise skipProp
                 val singletonT = PropertySet.fromList [(Property.fromKindValueAttributes (Kind.Type, Property.Type t, []))]
                 val singletonP = PropertySet.fromList [p]
-                val n = #2 (Property.getNumFunction "occurrences" p) handle Property.NoAttribute _ => 0.0
+                val g = QProperty.logGravity q handle Property.NoAttribute _ => 0.0
                 fun mkCorrs [] = []
                   | mkCorrs (((x,y,s),i)::L) =
                       if PropertySet.isEmpty (Correspondence.leftMatches singletonT (x,y,s))
                       then (if PropertySet.isEmpty (Correspondence.leftMatches singletonP (x,y,s)) then mkCorrs L else raise skipProp)
-                      else ((F.Atom p, F.Atom (Property.fromKindValueAttributes (Kind.Dummy, Property.Label ("\"" ^ F.toString Property.toString y ^ "\""), [])),s), i*i'*(1.0 + Math.ln(n + 1.0)/Math.ln(2.0))) :: mkCorrs L
+                      else ((F.Atom p, F.Atom (Property.fromKindValueAttributes (Kind.Dummy, Property.Label ("\"" ^ F.toString Property.toString y ^ "\""), [])),s), i*g) :: mkCorrs L
             in mkCorrs corrs
             end handle skipProp => [] (* This is the hackiest thing ever, but it should take care of cases when there is already a correspondence for the property, so we don't need to add it from its type *)
     in List.concat (QPropertySet.map tCorrs qProps)

--- a/src/strategies/properties/importance.sml
+++ b/src/strategies/properties/importance.sml
@@ -48,8 +48,7 @@ fun toString x = if x < 0.0 then "Noise"
             else if x <= 1.0/3.0 then "Low"
             else if x <= 2.0/3.0 then "Medium"
             else if x <= 1.0 then "High"
-            else if x > 1.0 then "Super High (thanks logGravity!)"
-            else (print "bad importance value"; raise Match);
+            else "Super High (thanks logGravity!)";
 
 val max = Real.max;
 val min = Real.min;

--- a/src/strategies/properties/importance.sml
+++ b/src/strategies/properties/importance.sml
@@ -48,6 +48,7 @@ fun toString x = if x < 0.0 then "Noise"
             else if x <= 1.0/3.0 then "Low"
             else if x <= 2.0/3.0 then "Medium"
             else if x <= 1.0 then "High"
+            else if x > 1.0 then "Super High (thanks logGravity)"
             else (print "bad importance value"; raise Match);
 
 val max = Real.max;

--- a/src/strategies/properties/importance.sml
+++ b/src/strategies/properties/importance.sml
@@ -48,7 +48,7 @@ fun toString x = if x < 0.0 then "Noise"
             else if x <= 1.0/3.0 then "Low"
             else if x <= 2.0/3.0 then "Medium"
             else if x <= 1.0 then "High"
-            else if x > 1.0 then "Super High (thanks logGravity)"
+            else if x > 1.0 then "Super High (thanks logGravity!)"
             else (print "bad importance value"; raise Match);
 
 val max = Real.max;

--- a/src/strategies/properties/importance.sml
+++ b/src/strategies/properties/importance.sml
@@ -48,6 +48,7 @@ fun toString x = if x < 0.0 then "Noise"
             else if x <= 1.0/3.0 then "Low"
             else if x <= 2.0/3.0 then "Medium"
             else if x <= 1.0 then "High"
+            else if x > 1.0 then "Super High (thanks logGravity!)"
             else (print "bad importance value"; raise Match);
 
 val max = Real.max;

--- a/src/strategies/properties/kind.sml
+++ b/src/strategies/properties/kind.sml
@@ -34,7 +34,7 @@ struct
 exception KindError;
 type kind = string;
 
-val Dummy = "dummy";
+val Dummy = "__";
 val Token = "token";
 val Type = "type";
 val Law = "law";

--- a/src/strategies/properties/kind.sml
+++ b/src/strategies/properties/kind.sml
@@ -3,6 +3,7 @@ sig
     exception KindError;
     eqtype kind;
 
+    val Dummy : kind;
     val Token : kind;
     val Type : kind;
     val Law : kind;
@@ -33,6 +34,7 @@ struct
 exception KindError;
 type kind = string;
 
+val Dummy = "dummy";
 val Token = "token";
 val Type = "type";
 val Law = "law";

--- a/src/strategies/properties/property.sml
+++ b/src/strategies/properties/property.sml
@@ -13,6 +13,7 @@ sig
 
     datatype value = Label of string | Number of int | Boolean of bool | Type of Type.T | Raw of string;
     type property;
+
     structure M : MULTISET;
     val toListHandlingNegatives : (int -> int) -> Type.T M.multiset -> Type.T list;
     val toPairList : Type.T M.multiset -> (Type.T * int) list;
@@ -71,6 +72,7 @@ fun stringOfValue (Label s) = s
   | stringOfValue (Raw s) = "RAW: " ^ s;
 
 type property = (Kind.kind * value * Attribute.T list);
+
 structure M = Attribute.M
 
 fun toListHandlingNegatives f m = M.toListHandlingNegatives f m;
@@ -117,8 +119,8 @@ fun typeFromAttributes [] = NONE
 
 exception NoAttribute of string;
 
-fun getTypeOfValue (k, Label v,A) = (case typeFromAttributes A of SOME t => t
-                                                        | NONE => raise NoAttribute ("type"))
+fun getTypeOfValue (k, Label v,A) =
+    (case typeFromAttributes A of SOME t => t | NONE => raise NoAttribute "type")
   | getTypeOfValue (k,v,A) = raise NoAttribute "type";
 
 fun getHoles (_,_,[]) = raise NoAttribute "holes"

--- a/src/strategies/representation_selection.sml
+++ b/src/strategies/representation_selection.sml
@@ -129,6 +129,8 @@ fun propInfluence (q, r, s) =
                                                                qProps rProps;
             in map liftImportance correspondences end;
 
+        val typeMatches = typeCorrespondences matches qProps';
+
         val modulate = Importance.modulate;
         val strength = Correspondence.strength;
         (* Sort correspondences from most to least important *)
@@ -153,7 +155,7 @@ fun propInfluence (q, r, s) =
                      in
                          s'
                      end;
-        val s' = List.foldl mix s (sort matches);
+        val s' = List.foldl mix s ((sort matches) @ typeMatches);
     in
         Logging.write ("\n");
         Logging.write ("RETURN ("

--- a/tables/Q_table_intsum_algebra.csv
+++ b/tables/Q_table_intsum_algebra.csv
@@ -1,13 +1,32 @@
 intsum,algebra
 error_allowed,0
+mode,"sentential"
 answer_type,integer
-instrumental_types,"integer,proof"
-instrumental_tokens,"\sum,*,="
-instrumental_patterns,"$sum, $equality_chain"
+instrumental_types,"proof"
+instrumental_tokens,"\sum:{type:= 'a set * ('a -> integer) -> integer; occurrences := 1},
+                     *:{type:= integer * integer -> integer; occurrences := 0},
+                     =:{type:= integer * integer -> formula; occurrences := 0}"
+instrumental_patterns,"$sum : {type:= formula;
+                                holes := ['a set * ('a -> integer) -> integer => 1.
+                                          'a set => 1.
+                                          'a -> integer => 1.
+                                          integer => 1];
+                                tokens := [\sum. =];
+                                token_registration := 1;
+                                occurrences := 0},
+                       $equality_chain : {type := proof;
+                                          holes := [integer => log(#t)];
+                                          tokens := [=];
+                                          token_registration := 1;
+                                          occurrences := 0}"
 instrumental_laws,""
 instrumental_tactics,"induction"
-relevant_tokens,"n:{type:=integer}, i:{type:=integer}, +, \div,
-                 - : {occurrences := 0},^ : {occurrences := 0},\sqrt : {occurrences := 0},0 : {occurrences := 0}"
-num_tokens,14
-num_distinct_tokens,9
+relevant_tokens,"n:{type:=integer; occurrences := 1},
+                 i:{type:=integer; occurrences := 1},
+                 +:{type:=integer * integer -> integer; occurrences := 0},
+                 \div:{type:=integer * integer -> integer; occurrences := 0},
+                 - : {type:=integer * integer -> integer; occurrences := 0},
+                 ^ : {type:=integer * integer -> integer; occurrences := 0},
+                 1 : {type:= integer; occurrences := 0},
+                 0 : {type:= integer; occurrences := 0}"
 noise_tokens,""


### PR DESCRIPTION
if x has type t and we have a satisfied correspondence <t,F,s>, then we can infer <x,y,s> where y is something that satisfies F. This idea is now automated.
Moreover, every correspondence <q,r,s> is modulated by the logGravity of q. This is proportional to the importance of q and the log of its number of occurrences. This has also been included now.