### PR TITLE
Unit test kickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Thumbs.db
 .robin/
 dist/
 base.sml
+tests/test

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ FLAGS=
 ROBIN_TMP:=$(shell mktemp)
 FINDCORR_TMP:=$(shell mktemp)
 UNIONTABLE_TMP:=$(shell mktemp)
+TEST_TMP:=$(shell mktemp)
 ROBIN_VERSION:=$(shell git describe --all --long | rev | cut -d'-' -f 1 | rev)
 
 all: dist/robin dist/findcorr dist/uniontables
@@ -62,6 +63,23 @@ base.sml:
 	echo 'val ROBIN_VERSION="'$(ROBIN_VERSION)'";' >> base.sml
 	echo 'val BASE="./src/";' >> base.sml
 	echo 'use "src/util/robinlib.sml";' >> base.sml
+
+
+test: tests/test
+	$<
+
+tests/test: $(TEST_TMP)
+	$(MLC) $(FLAGS) -o $@ $<
+
+.PHONY:$(TEST_TMP)
+$(TEST_TMP): base.sml tests/tests.sml
+	echo "use\""$<"\";" >> $@;
+	for f in $(filter-out base.sml,$^); do \
+		tmp=$$(dirname $$f)/$$(basename $$f); \
+		tmp=$$(sed "s/^src\///" <<< $$tmp); \
+		echo "use \"$$tmp\";" >> $@ ; \
+	done
+
 
 .PHONY:clean
 clean:

--- a/src/util/robinlib.sml
+++ b/src/util/robinlib.sml
@@ -233,13 +233,13 @@ fun replicate n x =
         unfold gen n
     end;
 
-fun max _ [] = raise List.Empty
+fun max _ [] = raise Empty
   | max cmp (x::xs) = List.foldl (fn (a, b) => if cmp(a, b) = GREATER
                                                then a
                                                else b)
                                  x xs;
 
-fun min _ [] = raise List.Empty
+fun min _ [] = raise Empty
   | min cmp (x::xs) = List.foldl (fn (a, b) => if cmp(a, b) = LESS
                                                then a
                                                else b)

--- a/src/util/robinlib.sml
+++ b/src/util/robinlib.sml
@@ -184,15 +184,14 @@ fun enumerate xs = enumerateFrom 0 xs;
 
 fun filterOption xs = mapPartial (fn x => x) xs;
 
-fun findAndRemove _ _ [] = (false,[])
-  | findAndRemove f x (a::L) =
+fun findAndRemoveOnce _ _ [] = (false,[])
+  | findAndRemoveOnce f x (a::L) =
       if f (x, a) then (true,L)
-      else let val (found,L') = findAndRemove f x L
+      else let val (found,L') = findAndRemoveOnce f x L
            in (found,a::L')
            end;
-
 fun isPermutationOf _ [] [] = true
-  | isPermutationOf f (a::A) B = let val (found,B') = findAndRemove f a B
+  | isPermutationOf f (a::A) B = let val (found,B') = findAndRemoveOnce f a B
                                  in if found then isPermutationOf f A B'
                                     else false
                                  end

--- a/src/util/robinlib.sml
+++ b/src/util/robinlib.sml
@@ -182,9 +182,7 @@ fun enumerateFrom start list =
 
 fun enumerate xs = enumerateFrom 0 xs;
 
-fun filterOption [] = []
-  | filterOption (NONE :: L) = filterOption L
-  | filterOption ((SOME x) :: L) = x :: filterOption L;
+fun filterOption xs = mapPartial (fn x => x) xs;
 
 fun findAndRemove _ _ [] = (false,[])
   | findAndRemove f x (a::L) =

--- a/tests/test_base.sml
+++ b/tests/test_base.sml
@@ -1,4 +1,4 @@
-signature TESTSUIT =
+signature TESTSUITE =
 sig
 
     exception TestFail of string;
@@ -13,7 +13,7 @@ sig
 
 end;
 
-structure TestSuit : TESTSUIT =
+structure TestSuite : TESTSUITE =
 struct
 
 exception TestFail of string;

--- a/tests/test_base.sml
+++ b/tests/test_base.sml
@@ -28,7 +28,10 @@ val tests: test list ref = ref [];
 fun register f = tests := (f::(!tests));
 
 fun assertEqual f a s =
-    fn () => if f () = a then () else raise TestFail s;
+    fn () => (if f () = a then () else raise TestFail s)
+             handle TestFail s => raise TestFail s
+                  | e => raise TestFail ("Exception " ^ (exnMessage e) ^
+                                         " while running test: \"" ^ s ^ "\"");
 
 fun assertTrue f s = assertEqual f true s;
 

--- a/tests/test_base.sml
+++ b/tests/test_base.sml
@@ -6,6 +6,8 @@ sig
     val register : (unit -> unit) -> unit;
 
     val assertEqual : (unit -> ''a) -> ''a -> string -> (unit -> unit);
+    val assertTrue : (unit -> bool) -> string -> (unit -> unit);
+    val assertFalse : (unit -> bool) -> string -> (unit -> unit);
 
     val run : unit -> (int * string list);
 
@@ -22,6 +24,10 @@ fun register f = tests := (f::(!tests));
 
 fun assertEqual f a s =
     fn () => if f () = a then () else raise TestFail s;
+
+fun assertTrue f s = assertEqual f true s;
+
+fun assertFalse f s = assertEqual f false s;
 
 fun run () =
     let

--- a/tests/test_base.sml
+++ b/tests/test_base.sml
@@ -1,0 +1,41 @@
+signature TESTSUIT =
+sig
+
+    exception TestFail of string;
+
+    val register : (unit -> unit) -> unit;
+
+    val run : unit -> (int * string list);
+
+end;
+
+structure TestSuit : TESTSUIT =
+struct
+
+exception TestFail of string;
+
+val tests: (unit -> unit) list ref = ref [];
+
+fun register f = tests := (f::(!tests));
+
+fun run () =
+    let
+        fun loop (count, failures) [] = (count, List.rev failures)
+          | loop (count, failures) (f::fs) =
+            let val (c, s) = (f (); (true, ""))
+                             handle TestFail s' => (false, s');
+                val _ = print (if c then "." else "!");
+            in loop (count + (if c then 0 else 1), s::failures) fs end;
+        fun printAll [] = ()
+          | printAll (s::ss) = (if s <> "" then print (s ^ "\n") else ();
+                                printAll ss);
+
+        val (failCount, errors) = loop (0, []) (List.rev (!tests));
+        val _ = print "\n";
+        val _ = if failCount = 0
+                then print "\nAll tests passed.\n"
+                else (print ((Int.toString failCount) ^ " tests failed.\n\n");
+                      printAll errors);
+    in (failCount, errors) end;
+
+end;

--- a/tests/test_base.sml
+++ b/tests/test_base.sml
@@ -39,7 +39,8 @@ fun assertFalse f s = assertEqual f false s;
 
 fun assertError f e s =
     fn () => let val _ = f () in raise TestFail s end
-             handle e' => if (exnMessage e) = (exnMessage e')
+             handle TestFail s => raise TestFail s
+                  | e' => if (exnMessage e) = (exnMessage e')
                           then ()
                           else raise TestFail s;
 

--- a/tests/test_base.sml
+++ b/tests/test_base.sml
@@ -5,6 +5,8 @@ sig
 
     val register : (unit -> unit) -> unit;
 
+    val assertEqual : (unit -> ''a) -> ''a -> string -> (unit -> unit);
+
     val run : unit -> (int * string list);
 
 end;
@@ -17,6 +19,9 @@ exception TestFail of string;
 val tests: (unit -> unit) list ref = ref [];
 
 fun register f = tests := (f::(!tests));
+
+fun assertEqual f a s =
+    fn () => if f () = a then () else raise TestFail s;
 
 fun run () =
     let

--- a/tests/test_base.sml
+++ b/tests/test_base.sml
@@ -36,10 +36,12 @@ fun run () =
                                 printAll ss);
 
         val (failCount, errors) = loop (0, []) (List.rev (!tests));
+        val testCount = List.length (!tests);
         val _ = print "\n";
+        val ratio = "(" ^ (Int.toString (testCount - failCount)) ^ "/" ^ (Int.toString testCount) ^ ")";
         val _ = if failCount = 0
-                then print "\nAll tests passed.\n"
-                else (print ((Int.toString failCount) ^ " tests failed.\n\n");
+                then print ("\nAll tests passed " ^ ratio ^ ".\n")
+                else (print ((Int.toString failCount) ^ " tests failed " ^ ratio ^ ".\n\n");
                       printAll errors);
     in (failCount, errors) end;
 

--- a/tests/test_comparison.sml
+++ b/tests/test_comparison.sml
@@ -24,3 +24,26 @@ TestSuite.register (
         GREATER
         "Comparison: join on pair for GREATER on first"
 );
+
+(* rev *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Comparison.rev Int.compare (5, 5))
+        EQUAL
+        "Comparison: rev to EQUAL is still EQUAL"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Comparison.rev Int.compare (10, 5))
+        LESS
+        "Comparison: rev to GREATER is now LESS"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Comparison.rev Int.compare (2, 20))
+        GREATER
+        "Comparison: rev to LESS is now GREATER"
+);

--- a/tests/test_comparison.sml
+++ b/tests/test_comparison.sml
@@ -1,0 +1,26 @@
+(*
+Test the new Comparison structure
+*)
+
+(* join *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Comparison.join Int.compare String.compare ((5, "a"), (5, "a")))
+        EQUAL
+        "Comparison: join on pair for EQUAL"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Comparison.join Int.compare String.compare ((5, "a"), (5, "b")))
+        LESS
+        "Comparison: join on pair for LESS on second"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Comparison.join Int.compare String.compare ((6, "a"), (5, "b")))
+        GREATER
+        "Comparison: join on pair for GREATER on first"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -507,3 +507,51 @@ TestSuite.register (
             "List: split then concat is original list"
     end
 );
+
+(* rotate *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.rotate 5 [])
+        []
+        "List: rotate empty list is still empty"
+);
+
+TestSuite.register (
+    let val l = ["a", "b", "c", "d"] in
+        TestSuite.assertEqual
+            (fn () => List.rotate 0 l)
+            l
+            "List: rotate by zero is original"
+    end
+);
+
+TestSuite.register (
+    let val l = ["a", "b", "c", "d"] in
+        TestSuite.assertEqual
+            (fn () => List.rotate (List.length l) l)
+            l
+            "List: rotate by entire length is original"
+    end
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.rotate 2 [1, 2, 3, 4, 5])
+        [3, 4, 5, 1, 2]
+        "List: rotate by value in [0, ..., length - 1]"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.rotate ~2 [1, 2, 3, 4, 5])
+        [4, 5, 1, 2, 3]
+        "List: rotate by negative value moves backward"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.rotate 8 [1, 2, 3, 4, 5])
+        [4, 5, 1, 2, 3]
+        "List: rotate by value beyond length wraps around"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -131,3 +131,42 @@ TestSuite.register (
         ["a", "x", "b", "x", "c", "x", "d", "x", "e"]
         "List: intersperse string"
 );
+
+(* enumerate *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.enumerate [])
+        []
+        "List: enumerate empty remains empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.enumerate ["a", "b", "c"])
+        [(0, "a"), (1, "b"), (2, "c")]
+        "List: enumerate string list"
+);
+
+(* enumerateFrom *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.enumerateFrom 100 [])
+        []
+        "List: enumerateFrom empty remains empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.enumerateFrom 100 [1, 2, 3])
+        [(100, 1), (101, 2), (102, 3)]
+        "List: enumerateFrom int list"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.enumerateFrom ~4 [false, true, false])
+        [(~4, false), (~3, true), (~2, false)]
+        "List: enumerateFrom negative start on bool list"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -314,8 +314,28 @@ TestSuite.register (
 );
 
 (* toString *)
-(* This would be very obvious if it broke, and not very important.
-   As such I'm not going to bother testing it. *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.toString Int.toString [])
+        "[]"
+        "List: toString of empty is \"[]\""
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.toString (fn x => x) ["hello"])
+        "[hello]"
+        "List: toString of singleton has no commas"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.toString Real.toString [1.2, 2.4])
+        "[1.2, 2.4]"
+        "List: toString on real list"
+);
+
 
 (* unfold *)
 

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -390,6 +390,40 @@ in
     ()
 end;
 
+(* argmin, argmax *)
+
+let
+    fun testEmpty fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertError
+                (fn () => #1 (fnc Real.fromInt []))
+                List.Empty
+                ("List: " ^ fnstr ^ " of an empty list is an error"));
+    fun testSingleton fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertEqual
+                (fn () => #1 (fnc Real.fromInt [42]))
+                42
+                ("List: " ^ fnstr ^ " of singleton is its value"));
+    fun testRepeated fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertEqual
+                (fn () => #1 (fnc Real.fromInt [2, 2, 2, 2, 2]))
+                2
+                ("List: " ^ fnstr ^ " of repeated element is that element"));
+    fun testGeneral fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertEqual
+                (fn () => #1 (fnc Real.fromInt [3, 1, 6, 3, 1, 2, 7, 4]))
+                (if fnstr = "argmin" then 1 else 7)
+                ("List: " ^ fnstr ^ " is correct"));
+    val tests = [testEmpty, testSingleton, testRepeated, testGeneral];
+in
+    map (fn t => t List.argmin "argmin") tests;
+    map (fn t => t List.argmax "argmax") tests;
+    ()
+end;
+
 (* takeWhile *)
 
 TestSuite.register (
@@ -555,3 +589,7 @@ TestSuite.register (
         [4, 5, 1, 2, 3]
         "List: rotate by value beyond length wraps around"
 );
+
+(* weightedSumIndexed, sumIndexed, weightedSum, sum *)
+
+(* weightAvgIndexed, avgIndexed, weightedAvg, avg *)

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -232,3 +232,19 @@ TestSuite.register (
         (fn () => List.isPermutationOf op= [1, 2, 3, 4, 5, 6] [2, 4, 1, 5, 6, 3])
         "List: isPermutationOf works"
 );
+
+(* mapArgs *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.mapArgs (fn x => x) [])
+        []
+        "List: mapArgs empty remains empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.mapArgs Int.toString [1, 2, 3])
+        [(1, "1"), (2, "2"), (3, "3")]
+        "List: mapArgs on int list"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -639,3 +639,50 @@ TestSuite.register (
 );
 
 (* weightAvgIndexed, avgIndexed, weightedAvg, avg *)
+
+let
+    val w = fn r => 1.0;
+    val i = fn r => r;
+    fun mkTest (f, s) =
+        TestSuite.register (
+            TestSuite.assertError
+                (fn () => f [])
+                List.Empty
+                ("List: " ^ s ^ " on empty list is an Empty error")
+        );
+in
+    map mkTest [(List.weightedAvgIndexed w i, "weightedAvgIndexed"),
+                (List.avgIndexed i, "avgIndexed"),
+                (List.weightedAvg w, "weightedAvg"),
+                (List.avg, "avg")]
+end;
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.==(List.weightedAvgIndexed (fn (_, c) => Real.fromInt c)
+                                                  (Real.fromInt o String.size o #1)
+                                                  [("hi", 2), ("hey", 3), ("hello", 1)],
+                          3.0))
+        "List: weightedAvgIndexed on (string * int) list, indexing by string length, weighting by the 'count'"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.==(List.avgIndexed (Real.fromInt o List.length) [[0], [0, 0], [0]],
+                          4.0/3.0))
+        "List: avgIndexed on int list list, indexed by length"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.== (List.weightedAvg (fn x => x * x) [1.0, 2.0, 1.0, 0.5],
+                           1.62))
+        "List: weightedAvg on where weight is the square of the value"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.== (List.avg [4.0, 1.0, 3.0, 2.6],
+                           2.65))
+        "List: avg works correctly"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -32,3 +32,40 @@ TestSuite.register (
         []
         "List: remove on bools, empty list"
 );
+
+(* removeDuplicates *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.removeDuplicates [])
+        []
+        "List: removeDuplicates on empty list"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.removeDuplicates [9, 7, 3, 2, 6])
+        [9, 7, 3, 2, 6]
+        "List: removeDuplicates on list of unique integers"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.removeDuplicates [1, 1, 2, 3, 5, 8, 1])
+        [1, 2, 3, 5, 8]
+        "List: removeDuplicates on integers, single duplicated element"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.removeDuplicates [1, 2, 1, 2, 1, 2, 3, 3, 3])
+        [1, 2, 3]
+        "List: removeDuplicates on integers, multiple duplicated elements"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.removeDuplicates ["a", "a", "a", "a"])
+        ["a"]
+        "List: removeDuplicates on strings, all elements the same"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -312,3 +312,7 @@ TestSuite.register (
          ("c", 1), ("c", 2)]
         "List: product with heterogeneous lists (string, int)"
 );
+
+(* toString *)
+(* This would be very obvious if it broke, and not very important.
+   As such I'm not going to bother testing it. *)

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -108,3 +108,26 @@ TestSuite.register (
         [1, 2, 3, 4, 5, 7, 100]
         "List: mergesort int list without duplicates"
 );
+
+(* intersperse *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.intersperse 0 [])
+        []
+        "List: intersperse into empty still empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.intersperse false [true])
+        [true]
+        "List: intersperse into singleton still singleton"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.intersperse "x" ["a", "b", "c", "d", "e"])
+        ["a", "x", "b", "x", "c", "x", "d", "x", "e"]
+        "List: intersperse string"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -1,0 +1,34 @@
+(*
+Test the extended List structure.
+*)
+
+(* remove *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.remove 5 [3, 5, 7, 9])
+        [3, 7, 9]
+        "List: remove on ints, no duplicates"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.remove "x" ["w", "x", "z", "y", "x", "a"])
+        (* This removes ALL occurrences of x *)
+        ["w", "z", "y", "a"]
+        "List: remove on strings, with duplicates"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.remove #"a" [#"b", #"c"])
+        [#"b", #"c"]
+        "List: remove on chars, needle not occurring"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.remove false [])
+        []
+        "List: remove on bools, empty list"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -170,3 +170,33 @@ TestSuite.register (
         [(~4, false), (~3, true), (~2, false)]
         "List: enumerateFrom negative start on bool list"
 );
+
+(* filterOption *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.filterOption [])
+        []
+        "List: filterOption empty remains empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.filterOption [SOME 1, SOME 2, SOME 3])
+        [1, 2, 3]
+        "List: filterOption all SOME"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.filterOption [NONE, NONE, NONE])
+        []
+        "List: filterOption all NONE"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.filterOption [SOME "a", NONE, SOME "b", SOME "c", NONE, NONE])
+        ["a", "b", "c"]
+        "List: filterOption on string option list"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -421,3 +421,35 @@ TestSuite.register (
         ["sup", "hey"]
         "List: takeWhile on string list"
 );
+
+(* dropWhile *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.dropWhile (fn x => false) [])
+        []
+        "List: dropWhile empty is empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.dropWhile (fn x => true) [1, 2, 3, 4, 5])
+        []
+        "List: dropWhile true is empty"
+);
+
+TestSuite.register (
+    let val l = [5, 4, 3, 2, 1];
+    in TestSuite.assertEqual
+           (fn () => List.dropWhile (fn x => false) l)
+           l
+           "List: dropWhile false is original list"
+    end
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.dropWhile (fn x => String.size x = 3) ["sup", "hey", "hello", "wow"])
+        ["hello", "wow"]
+        "List: dropWhile on string list"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -389,3 +389,35 @@ in
     map (fn t => t List.max "max") tests;
     ()
 end;
+
+(* takeWhile *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.takeWhile (fn x => true) [])
+        []
+        "List: takeWhile empty is empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.takeWhile (fn x => false) [1, 2, 3, 4, 5])
+        []
+        "List: takeWhile false is empty"
+);
+
+TestSuite.register (
+    let val l = [5, 4, 3, 2, 1];
+    in TestSuite.assertEqual
+           (fn () => List.takeWhile (fn x => true) l)
+           l
+           "List: takeWhile true is original list"
+    end
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.takeWhile (fn x => String.size x = 3) ["sup", "hey", "hello", "wow"])
+        ["sup", "hey"]
+        "List: takeWhile on string list"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -69,3 +69,42 @@ TestSuite.register (
         ["a"]
         "List: removeDuplicates on strings, all elements the same"
 );
+
+(* mergesort *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.mergesort String.compare [])
+        []
+        "List: mergesort empty list"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.mergesort Int.compare [0])
+        [0]
+        "List: mergesort singleton"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.mergesort String.compare ["x", "x", "x", "x"])
+        ["x", "x", "x", "x"]
+        "List: mergesort all equal"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => let fun cmp ((a, b), (x, y)) =  String.compare (a, x);
+                  in List.mergesort cmp [("a", 2), ("a", 1), ("a", 3)] end)
+        [("a", 2), ("a", 1), ("a", 3)]
+        "List: mergesort all equal, stable"
+
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.mergesort Int.compare [2, 3, 1, 5, 7, 4, 100])
+        [1, 2, 3, 4, 5, 7, 100]
+        "List: mergesort int list without duplicates"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -453,3 +453,57 @@ TestSuite.register (
         ["hello", "wow"]
         "List: dropWhile on string list"
 );
+
+(* split *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.split ([], 0))
+        ([], [])
+        "List: split empty at position 0 is fine"
+);
+
+TestSuite.register (
+    TestSuite.assertError
+        (fn () => List.split (["a"], 2))
+        Subscript
+        "List: split beyond length is error"
+);
+
+TestSuite.register (
+    let val l = [1, 2, 3, 4];
+        val k = List.length l;
+    in
+        TestSuite.assertEqual
+            (fn () => List.split (l, k))
+            (l, [])
+            "List: split at end is original with an empty list"
+    end
+);
+
+TestSuite.register (
+    let val l = [1, 2, 3, 4];
+    in
+        TestSuite.assertEqual
+            (fn () => List.split (l, 0))
+            ([], l)
+            "List: split at 0 is an empty list with original"
+    end
+);
+
+TestSuite.register (
+    TestSuite.assertError
+        (fn () => List.split ([1, 2, 3, 4, 5], ~1))
+        Subscript
+        "List: split on negative number is an error"
+);
+
+TestSuite.register (
+    let val l = ["hi", "salut", "hola", "kia ora"];
+        val k = 2;
+    in
+        TestSuite.assertTrue
+            (fn () => (op@ (List.split (l, k))) = l)
+            "List: split then concat is original list"
+    end
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -200,3 +200,35 @@ TestSuite.register (
         ["a", "b", "c"]
         "List: filterOption on string option list"
 );
+
+(* isPermutationof *)
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => List.isPermutationOf op= [] [])
+        "List: isPermutationOf empty"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => List.isPermutationOf op= [1] [1])
+        "List: isPermutationof singleton integer"
+);
+
+TestSuite.register (
+    TestSuite.assertFalse
+        (fn () => List.isPermutationOf op= [1, 2, 2] [2, 1])
+        "List: isPermutationOf understands duplicates"
+);
+
+TestSuite.register (
+    TestSuite.assertFalse
+        (fn () => List.isPermutationOf op= [1, 1, 2, 2, 2] [1, 1, 1, 2, 2])
+        "List: isPermutationOf handles duplicates correctly"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => List.isPermutationOf op= [1, 2, 3, 4, 5, 6] [2, 4, 1, 5, 6, 3])
+        "List: isPermutationOf works"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -248,3 +248,26 @@ TestSuite.register (
         [(1, "1"), (2, "2"), (3, "3")]
         "List: mapArgs on int list"
 );
+
+(* flatmap *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.flatmap (fn x => x) [])
+        []
+        "List: flatmap empty remains empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.flatmap (fn x => []) [1, 2, 3, 4])
+        []
+        "List: flatmap with all empty results is empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.flatmap (fn s => String.explode s) ["hi", "there"])
+        [#"h", #"i", #"t", #"h", #"e", #"r", #"e"]
+        "List: flatmap strings to chars"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -592,4 +592,50 @@ TestSuite.register (
 
 (* weightedSumIndexed, sumIndexed, weightedSum, sum *)
 
+let
+    val w = fn r => 1.0;
+    val i = fn r => r;
+    fun mkTest (f, s) =
+        TestSuite.register (
+            TestSuite.assertTrue
+                (fn () => Real.== ((f []), 0.0))
+                ("List: " ^ s ^ " on empty list is 0")
+        );
+in
+    map mkTest [(List.weightedSumIndexed w i, "weightedSumIndexed"),
+                (List.sumIndexed i, "sumIndexed"),
+                (List.weightedSum w, "weightedSum"),
+                (List.sum, "sum")]
+end;
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.==(List.weightedSumIndexed (fn (_, c) => Real.fromInt c)
+                                                  (Real.fromInt o String.size o #1)
+                                                  [("hi", 2), ("hey", 3), ("hello", 1)],
+                          18.0))
+        "List: weightedSumIndexed on (string * int) list, indexing by string length, weighting by the 'count'"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.==(List.sumIndexed (Real.fromInt o List.length) [[0], [0, 0], [0]],
+                          4.0))
+        "List: sumIndexed on int list list, indexed by length"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.== (List.weightedSum (fn x => x * x) [1.0, 2.0, 1.0, 0.5],
+                           10.125))
+        "List: weightedSum on where weight is the square of the value"
+);
+
+TestSuite.register (
+    TestSuite.assertTrue
+        (fn () => Real.== (List.sum [4.0, 1.0, 3.0, 2.6],
+                           10.6))
+        "List: sum works correctly"
+);
+
 (* weightAvgIndexed, avgIndexed, weightedAvg, avg *)

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -332,3 +332,26 @@ TestSuite.register (
         ["0", "1", "2", "3", "4"]
         "List: unfold 0:int to strings of ints"
 );
+
+(* replicate *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.replicate 0 1)
+        []
+        "List: replicate zero times is empty"
+);
+
+TestSuite.register (
+    TestSuite.assertError
+        (fn () => List.replicate ~2 1)
+        Size
+        "List: replicate negative is a Size error"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.replicate 5 "a")
+        ["a", "a", "a", "a", "a"]
+        "List: replicate string"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -271,3 +271,44 @@ TestSuite.register (
         [#"h", #"i", #"t", #"h", #"e", #"r", #"e"]
         "List: flatmap strings to chars"
 );
+
+(* product *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.product ([], []))
+        []
+        "List: product both empty is empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.product ([1, 2, 3], []))
+        []
+        "List: product right empty is still empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.product ([], [4, 5, 6]))
+        []
+        "List: product left empty is still empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.product ([1, 2, 3], [10, 20, 30]))
+        [(1, 10), (1, 20), (1, 30),
+         (2, 10), (2, 20), (2, 30),
+         (3, 10), (3, 20), (3, 30)]
+        "List: product with homogeneous lists (int)"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.product (["a", "b", "c"], [1, 2]))
+        [("a", 1), ("a", 2),
+         ("b", 1), ("b", 2),
+         ("c", 1), ("c", 2)]
+        "List: product with heterogeneous lists (string, int)"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -316,3 +316,19 @@ TestSuite.register (
 (* toString *)
 (* This would be very obvious if it broke, and not very important.
    As such I'm not going to bother testing it. *)
+
+(* unfold *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.unfold (fn x => NONE) 0)
+        []
+        "List: unfold immediate NONE is empty"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => List.unfold (fn x => if x < 5 then SOME(Int.toString x, x+1) else NONE) 0)
+        ["0", "1", "2", "3", "4"]
+        "List: unfold 0:int to strings of ints"
+);

--- a/tests/test_list.sml
+++ b/tests/test_list.sml
@@ -355,3 +355,37 @@ TestSuite.register (
         ["a", "a", "a", "a", "a"]
         "List: replicate string"
 );
+
+(* max, min *)
+
+let
+    fun testEmpty fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertError
+                (fn () => fnc Int.compare [])
+                List.Empty
+                ("List: " ^ fnstr ^ " of an empty list is an error"));
+    fun testSingleton fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertEqual
+                (fn () => fnc Int.compare [42])
+                42
+                ("List: " ^ fnstr ^ " of singleton is its value"));
+    fun testRepeated fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertEqual
+                (fn () => fnc Int.compare [2, 2, 2, 2, 2])
+                2
+                ("List: " ^ fnstr ^ " of repeated element is that element"));
+    fun testGeneral fnc fnstr =
+        TestSuite.register (
+            TestSuite.assertEqual
+                (fn () => fnc Int.compare [3, 1, 6, 3, 1, 2, 7, 4])
+                (if fnstr = "min" then 1 else 7)
+                ("List: " ^ fnstr ^ " is correct"));
+    val tests = [testEmpty, testSingleton, testRepeated, testGeneral];
+in
+    map (fn t => t List.min "min") tests;
+    map (fn t => t List.max "max") tests;
+    ()
+end;

--- a/tests/test_option.sml
+++ b/tests/test_option.sml
@@ -1,0 +1,26 @@
+(*
+Test the extensions to the Option structure
+*)
+
+(* oneOf *)
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Option.oneOf [] 5)
+        NONE
+        "Option: oneOf empty is NONE"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Option.oneOf [(fn _ => NONE), (fn _ => NONE)] "a")
+        NONE
+        "Option: oneOf all functions that return NONE is NONE"
+);
+
+TestSuite.register (
+    TestSuite.assertEqual
+        (fn () => Option.oneOf [(fn x => SOME (x + 1)), (fn x => SOME (x + 2))] 0)
+        (SOME 1)
+        "Option: oneOf returns first result to return SOME value"
+);

--- a/tests/test_robinlib.sml
+++ b/tests/test_robinlib.sml
@@ -51,6 +51,52 @@ TestSuit.register (
 
 (* curry *)
 
+TestSuit.register (
+    let fun f (x, y) = Int.toString (x + (List.length y));
+        val arg1 = 37;
+        val arg2 = ["this", "is", "a", "test"];
+    in TestSuit.assertEqual
+           (fn () => curry f arg1 arg2)
+           (f (arg1, arg2))
+           "robinlib: curry on (int * 'a list) -> string"
+    end
+);
+
 (* uncurry *)
 
+TestSuit.register (
+    let fun f x y = y ^ " ~ " ^ (Real.toString x);
+        val arg1 = 3.14;
+        val arg2 = "Pi";
+    in TestSuit.assertEqual
+           (fn () => uncurry f (arg1, arg2))
+           (f arg1 arg2)
+           "robinlib: uncorry on real -> string -> string"
+    end
+);
+
 (* fails *)
+
+TestSuit.register (
+    TestSuit.assertTrue
+        (fn () => fails (fn () => 5 div 0))
+        "robinlib: fails on division by zero"
+);
+
+TestSuit.register (
+    TestSuit.assertFalse
+        (fn () => fails (fn () => 5.0 / 0.0)) (* = inf *)
+        "robinlib: fails on not-failing division by zero real"
+);
+
+TestSuit.register (
+    TestSuit.assertTrue
+        (fn () => fails (fn () => List.hd []))
+        "robinlib: fails on head of empty list"
+);
+
+TestSuit.register (
+    TestSuit.assertFalse
+        (fn () => fails (fn () => "hello"))
+        "robinlib: fails on not-failing function"
+);

--- a/tests/test_robinlib.sml
+++ b/tests/test_robinlib.sml
@@ -24,9 +24,30 @@ TestSuit.register (
 
 (* mapfst *)
 
+TestSuit.register (
+    TestSuit.assertEqual
+        (fn () => mapfst List.length ([8.2, 4.9, 7.0], "test"))
+        (3, "test")
+        "robinlib: mapfst on (real list * string) to (int * string)"
+);
+
 (* mapsnd *)
 
+TestSuit.register (
+    TestSuit.assertEqual
+        (fn () => mapsnd String.explode (42, "test"))
+        (42, [#"t", #"e", #"s", #"t"])
+        "robinlib: mapsnd on (int * string) to (int * char list)"
+);
+
 (* flip *)
+
+TestSuit.register (
+    TestSuit.assertEqual
+        (fn () => flip ("blah", [3, 1, 4]))
+        ([3, 1, 4], "blah")
+        "robinlib: flip on (string * int list)"
+);
 
 (* curry *)
 

--- a/tests/test_robinlib.sml
+++ b/tests/test_robinlib.sml
@@ -8,15 +8,15 @@ Test the robinlib utility functions
 
 (* mappair *)
 
-TestSuit.register (
-    TestSuit.assertEqual
+TestSuite.register (
+    TestSuite.assertEqual
         (fn () => mappair (fn x => x + 1) (10, 100))
         (11, 101)
         "robinlib: mappair across int pair"
 );
 
-TestSuit.register (
-    TestSuit.assertEqual
+TestSuite.register (
+    TestSuite.assertEqual
         (fn () => mappair (fn (a, b) => (b, a)) ((2, "a"), (7, "b")))
         (("a", 2), ("b", 7))
         "robinlib: mappair across (string * int) pair"
@@ -24,8 +24,8 @@ TestSuit.register (
 
 (* mapfst *)
 
-TestSuit.register (
-    TestSuit.assertEqual
+TestSuite.register (
+    TestSuite.assertEqual
         (fn () => mapfst List.length ([8.2, 4.9, 7.0], "test"))
         (3, "test")
         "robinlib: mapfst on (real list * string) to (int * string)"
@@ -33,8 +33,8 @@ TestSuit.register (
 
 (* mapsnd *)
 
-TestSuit.register (
-    TestSuit.assertEqual
+TestSuite.register (
+    TestSuite.assertEqual
         (fn () => mapsnd String.explode (42, "test"))
         (42, [#"t", #"e", #"s", #"t"])
         "robinlib: mapsnd on (int * string) to (int * char list)"
@@ -42,8 +42,8 @@ TestSuit.register (
 
 (* flip *)
 
-TestSuit.register (
-    TestSuit.assertEqual
+TestSuite.register (
+    TestSuite.assertEqual
         (fn () => flip ("blah", [3, 1, 4]))
         ([3, 1, 4], "blah")
         "robinlib: flip on (string * int list)"
@@ -51,11 +51,11 @@ TestSuit.register (
 
 (* curry *)
 
-TestSuit.register (
+TestSuite.register (
     let fun f (x, y) = Int.toString (x + (List.length y));
         val arg1 = 37;
         val arg2 = ["this", "is", "a", "test"];
-    in TestSuit.assertEqual
+    in TestSuite.assertEqual
            (fn () => curry f arg1 arg2)
            (f (arg1, arg2))
            "robinlib: curry on (int * 'a list) -> string"
@@ -64,11 +64,11 @@ TestSuit.register (
 
 (* uncurry *)
 
-TestSuit.register (
+TestSuite.register (
     let fun f x y = y ^ " ~ " ^ (Real.toString x);
         val arg1 = 3.14;
         val arg2 = "Pi";
-    in TestSuit.assertEqual
+    in TestSuite.assertEqual
            (fn () => uncurry f (arg1, arg2))
            (f arg1 arg2)
            "robinlib: uncorry on real -> string -> string"
@@ -77,26 +77,26 @@ TestSuit.register (
 
 (* fails *)
 
-TestSuit.register (
-    TestSuit.assertTrue
+TestSuite.register (
+    TestSuite.assertTrue
         (fn () => fails (fn () => 5 div 0))
         "robinlib: fails on division by zero"
 );
 
-TestSuit.register (
-    TestSuit.assertFalse
+TestSuite.register (
+    TestSuite.assertFalse
         (fn () => fails (fn () => 5.0 / 0.0)) (* = inf *)
         "robinlib: fails on not-failing division by zero real"
 );
 
-TestSuit.register (
-    TestSuit.assertTrue
+TestSuite.register (
+    TestSuite.assertTrue
         (fn () => fails (fn () => List.hd []))
         "robinlib: fails on head of empty list"
 );
 
-TestSuit.register (
-    TestSuit.assertFalse
+TestSuite.register (
+    TestSuite.assertFalse
         (fn () => fails (fn () => "hello"))
         "robinlib: fails on not-failing function"
 );

--- a/tests/test_robinlib.sml
+++ b/tests/test_robinlib.sml
@@ -1,0 +1,35 @@
+(*
+Test the robinlib utility functions
+*)
+
+(* import *)
+(* This is pretty much untestable without a lot of mock work.
+   It's probably fine, we'd have noticed it breaking! *)
+
+(* spread *)
+
+TestSuit.register (
+    TestSuit.assertEqual
+        (fn () => spread (fn x => x + 1) (10, 100))
+        (11, 101)
+        "robinlib: spread across int pair"
+);
+
+TestSuit.register (
+    TestSuit.assertEqual
+        (fn () => spread (fn (a, b) => (b, a)) ((2, "a"), (7, "b")))
+        (("a", 2), ("b", 7))
+        "robinlib: spread across (string * int) pair"
+);
+
+(* mapfst *)
+
+(* mapsnd *)
+
+(* flip *)
+
+(* curry *)
+
+(* uncurry *)
+
+(* fails *)

--- a/tests/test_robinlib.sml
+++ b/tests/test_robinlib.sml
@@ -6,20 +6,20 @@ Test the robinlib utility functions
 (* This is pretty much untestable without a lot of mock work.
    It's probably fine, we'd have noticed it breaking! *)
 
-(* spread *)
+(* mappair *)
 
 TestSuit.register (
     TestSuit.assertEqual
-        (fn () => spread (fn x => x + 1) (10, 100))
+        (fn () => mappair (fn x => x + 1) (10, 100))
         (11, 101)
-        "robinlib: spread across int pair"
+        "robinlib: mappair across int pair"
 );
 
 TestSuit.register (
     TestSuit.assertEqual
-        (fn () => spread (fn (a, b) => (b, a)) ((2, "a"), (7, "b")))
+        (fn () => mappair (fn (a, b) => (b, a)) ((2, "a"), (7, "b")))
         (("a", 2), ("b", 7))
-        "robinlib: spread across (string * int) pair"
+        "robinlib: mappair across (string * int) pair"
 );
 
 (* mapfst *)

--- a/tests/tests.sml
+++ b/tests/tests.sml
@@ -1,0 +1,21 @@
+use "./tests/test_base.sml";
+
+fun registerAll () =
+    let
+        val test_dir = "./tests/";
+        val test_dir_stream = OS.FileSys.openDir test_dir;
+        val test_files =
+            let fun streamToList ans s =
+                    case (OS.FileSys.readDir s) of
+                        SOME f => streamToList ((test_dir ^ f)::ans) s
+                      | NONE => List.rev ans
+            in streamToList [] test_dir_stream end;
+        fun isTest s = s <> "./tests/test_base.sml"
+                       andalso String.isPrefix (test_dir ^ "test_") s
+                       andalso String.isSuffix ".sml" s;
+    in List.app use (List.filter isTest test_files) end;
+
+fun main () =
+    let val _ = registerAll ();
+        val (c, _) = TestSuit.run();
+    in if c = 0 then 0 else 1 end;

--- a/tests/tests.sml
+++ b/tests/tests.sml
@@ -17,5 +17,5 @@ fun registerAll () =
 
 fun main () =
     let val _ = registerAll ();
-        val (c, _) = TestSuit.run();
+        val (c, _) = TestSuite.run();
     in if c = 0 then 0 else 1 end;


### PR DESCRIPTION
I want to write a suite of tests so we can make changes more easily. Right now, making a change needs to be manually tested to make sure we didn't break anything. This is tedious, and prone to error. Instead, this allows us to use `make test` and get an instant result.

In this PR I test most of the `robinlib` changes, including all the other structures that get defined/extended in the `robinlib.sml` file.

I have not tested `import` because it's so fundamental we'd notice, and it's a pain to test. 

I have not tested `TextIO.lookaheadN` because it is a pain to test.